### PR TITLE
Basic writer

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  pull-requests: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/source/lasPointRecord.cs
+++ b/source/lasPointRecord.cs
@@ -8,7 +8,7 @@ namespace streamlas
     internal delegate double get_double();
     internal delegate void void_method();
 
-    public class lasPointRecord
+    public class lasPointRecord : IDisposable
     {
         private byte format;
         private double[] scale;
@@ -176,5 +176,7 @@ namespace streamlas
             fixed (byte* b = &raw_data[16]) point_block_modern = *(PointBlockModern*)b;
             fixed (byte* b = &raw_data[time_index]) time = *(double*)b;
         }
+
+        public void Dispose() { }
     }
 }

--- a/source/lasPointRecord.cs
+++ b/source/lasPointRecord.cs
@@ -10,7 +10,7 @@ namespace streamlas
 
     public class lasPointRecord : IDisposable
     {
-        private byte format;
+        internal byte format;
         private double[] scale;
         private double[] offset;
         private byte[] raw_data;

--- a/source/lasPointRecord.cs
+++ b/source/lasPointRecord.cs
@@ -13,7 +13,7 @@ namespace streamlas
         internal byte format;
         private double[] scale;
         private double[] offset;
-        private byte[] raw_data;
+        internal byte[] raw_data;
 
         private PointBase point_base;
         private PointBlockLegacy point_block_legacy;

--- a/source/lasStreamReader.cs
+++ b/source/lasStreamReader.cs
@@ -133,7 +133,7 @@ namespace streamlas
                 IOException ex = new IOException("Input file " + Path.GetFileName(path)
                     + " is not a properly formatted LAS file.");
                 ex.Data["FileName"] = Path.GetFileName(path);
-                throw ex;
+                DisposeWithException(ex);
             }
 
             if (version_major == 0 || version_major > 1 || VersionMinor == 0 || VersionMinor > 4)
@@ -141,7 +141,7 @@ namespace streamlas
                 IOException ex = new IOException("LAS v" + version_major + "." + VersionMinor +
                     " is unsupported or not yet defined.");
                 ex.Data["FileName"] = Path.GetFileName(path);
-                throw ex;
+                DisposeWithException(ex);
             }
 
             if (PointFormat > lasConstants.MaxPointFormat[VersionMinor - 1])
@@ -149,7 +149,7 @@ namespace streamlas
                 IOException ex = new IOException("Point format " + PointFormat +
                     " is not supported in LAS v" + version_major + "." + VersionMinor);
                 ex.Data["FileName"] = Path.GetFileName(path);
-                throw ex;
+                DisposeWithException(ex);
             }
 
             if (header_size != lasConstants.HeaderSize[VersionMinor - 1])
@@ -157,7 +157,7 @@ namespace streamlas
                 IOException ex = new IOException("Reported header size incorrect for LAS v" + version_major +
                     "." + VersionMinor);
                 ex.Data["FileName"] = Path.GetFileName(path);
-                throw ex;
+                DisposeWithException(ex);
             }
 
             if (offset_to_points < lasConstants.HeaderSize[VersionMinor - 1])
@@ -165,38 +165,43 @@ namespace streamlas
                 IOException ex = new IOException("Reported offset to points shorter than header size for LAS v" +
                     version_major + "." + VersionMinor);
                 ex.Data["FileName"] = Path.GetFileName(path);
-                throw ex;
+                DisposeWithException(ex);
             }
 
             if (point_size < lasConstants.PointSize[PointFormat])
             {
                 IOException ex = new IOException("Reported point record size smaller than minimum required for Point Format " + PointFormat);
                 ex.Data["FileName"] = Path.GetFileName(path);
-                throw ex;
+                DisposeWithException(ex);
             }
 
             if (read_result == lasStreamResult.InconsistentCounts)
             {
                 IOException ex = new IOException("Inconsistency between Point Count and Legacy Point Count Fields.");
                 ex.Data["FileName"] = Path.GetFileName(path);
-                throw ex;
+                DisposeWithException(ex);
             }
 
             if (read_result == lasStreamResult.ImproperLegacy)
             {
                 IOException ex = new IOException("Point Format > 5 but legacy point count fields have non-zero values.");
                 ex.Data["FileName"] = Path.GetFileName(path);
-                throw ex;
+                DisposeWithException(ex);
             }
 
             if (PointCount * point_size != (UInt64)(reader.BaseStream.Length - offset_to_points))
             {
                 IOException ex = new IOException(Path.GetFileName(path) + " length is inconsistent with point size and count.");
                 ex.Data["FileName"] = Path.GetFileName(path);
-                throw ex;
+                DisposeWithException(ex);
             }
         }
 
         public void Dispose() { reader.Dispose(); }
+        private void DisposeWithException(Exception ex)
+        {
+            Dispose();
+            throw ex;
+        }
     }
 }

--- a/source/lasStreamReader.cs
+++ b/source/lasStreamReader.cs
@@ -13,7 +13,7 @@ namespace streamlas
 
         public UInt16 FileSourceID { get; private set; }
         
-        private UInt16 global_encoding;
+        internal UInt16 global_encoding;
         public bool HasTimestamps { get { return PointFormat != 0 && PointFormat != 2; } }
         public bool AdjustedGPSTime { get { return (global_encoding & 1) == 1; } }
         public bool SyntheticReturns { get { return (global_encoding & 8) == 8; } }

--- a/source/lasStreamWriter.cs
+++ b/source/lasStreamWriter.cs
@@ -11,7 +11,10 @@ namespace streamlas
         public lasStreamWriter(lasStreamReader reader, lasPointRecord point, string path)
         {
             writer = new BinaryWriter(File.Create(path));
-            writer.Write(Encoding.ASCII.GetBytes("LASF"));
+            writer.Write(Encoding.ASCII.GetBytes("LASF"));            
+            for (int i = 0; i < 20; i++) writer.Write((byte)0);
+            writer.Write((byte)1);
+            writer.Write(reader.VersionMinor);
         }
 
         public void Dispose() { writer.Dispose(); }

--- a/source/lasStreamWriter.cs
+++ b/source/lasStreamWriter.cs
@@ -28,7 +28,10 @@ namespace streamlas
             writer.Write((byte)1);
             writer.Write(reader.VersionMinor);
 
-            for (int i = 0; i < 68; i++) writer.Write((byte)0);
+            for (int i = 0; i < 64; i++) writer.Write((byte)0);
+            writer.Write((UInt16)DateTime.Now.DayOfYear);
+            writer.Write((UInt16)DateTime.Now.Year);
+
             writer.Write(lasConstants.HeaderSize[reader.VersionMinor - 1]);
             writer.Write((UInt32)lasConstants.HeaderSize[reader.VersionMinor - 1]);
 

--- a/source/lasStreamWriter.cs
+++ b/source/lasStreamWriter.cs
@@ -12,9 +12,13 @@ namespace streamlas
         {
             writer = new BinaryWriter(File.Create(path));
             writer.Write(Encoding.ASCII.GetBytes("LASF"));            
+            
             for (int i = 0; i < 20; i++) writer.Write((byte)0);
             writer.Write((byte)1);
             writer.Write(reader.VersionMinor);
+
+            for (int i = 0; i < 78; i++) writer.Write((byte)0);
+            writer.Write(point.format);
         }
 
         public void Dispose() { writer.Dispose(); }

--- a/source/lasStreamWriter.cs
+++ b/source/lasStreamWriter.cs
@@ -100,9 +100,15 @@ namespace streamlas
 
             if (point_format < 6)
             {
+                if (count > UInt32.MaxValue)
+                {
+                    writer.Dispose();
+                    throw new IOException("More points than UINT32_MAX written to file;" +
+                        "cannot be supported in legacy mode with Point Format " + point_format);
+                }
+
                 writer.BaseStream.Position = 107;
                 writer.Write((UInt32)count);
-
                 for (int i = 0; i < 5; i++) writer.Write((UInt32)return_counts[i]);
             }
 

--- a/source/lasStreamWriter.cs
+++ b/source/lasStreamWriter.cs
@@ -24,7 +24,13 @@ namespace streamlas
         {
             writer.Write(Encoding.ASCII.GetBytes("LASF"));
 
-            for (int i = 0; i < 20; i++) writer.Write((byte)0);
+            for (int i = 0; i < 4; i++) writer.Write((byte)0);
+
+            writer.Write(reader.GUID1);
+            writer.Write(reader.GUID2);
+            writer.Write(reader.GUID3);
+            writer.Write(reader.GUID4);
+
             writer.Write((byte)1);
             writer.Write(reader.VersionMinor);
 

--- a/source/lasStreamWriter.cs
+++ b/source/lasStreamWriter.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.IO;
+using System.Text;
+
+namespace streamlas
+{
+    public class lasStreamWriter : IDisposable
+    {
+        internal BinaryWriter writer;
+
+        public lasStreamWriter(lasStreamReader reader, lasPointRecord point, string path)
+        {
+            writer = new BinaryWriter(File.Create(path));
+            writer.Write(Encoding.ASCII.GetBytes("LASF"));
+        }
+
+        public void Dispose() { writer.Dispose(); }
+    }
+}

--- a/source/lasStreamWriter.cs
+++ b/source/lasStreamWriter.cs
@@ -23,6 +23,7 @@ namespace streamlas
 
             for (int i = 0; i < 4; i++) writer.Write((byte)0);
             writer.Write(point.format);
+            writer.Write(lasConstants.PointSize[point.format]);
         }
 
         public void Dispose() { writer.Dispose(); }

--- a/source/lasStreamWriter.cs
+++ b/source/lasStreamWriter.cs
@@ -39,7 +39,9 @@ namespace streamlas
             writer.Write(Encoding.ASCII.GetBytes(reader.SystemIdentifier));
             while (writer.BaseStream.Position < 58) writer.Write('\0');
 
-            for (int i = 0; i < 32; i++) writer.Write((byte)0);
+            writer.Write(Encoding.ASCII.GetBytes("streamlas - .NET LAS IO Library"));
+            while (writer.BaseStream.Position < 90) writer.Write('\0');
+
             writer.Write((UInt16)DateTime.Now.DayOfYear);
             writer.Write((UInt16)DateTime.Now.Year);
 

--- a/source/lasStreamWriter.cs
+++ b/source/lasStreamWriter.cs
@@ -17,7 +17,11 @@ namespace streamlas
             writer.Write((byte)1);
             writer.Write(reader.VersionMinor);
 
-            for (int i = 0; i < 78; i++) writer.Write((byte)0);
+            for (int i = 0; i < 68; i++) writer.Write((byte)0);
+            writer.Write(lasConstants.HeaderSize[reader.VersionMinor - 1]);
+            writer.Write((UInt32)lasConstants.HeaderSize[reader.VersionMinor - 1]);
+
+            for (int i = 0; i < 4; i++) writer.Write((byte)0);
             writer.Write(point.format);
         }
 

--- a/source/lasStreamWriter.cs
+++ b/source/lasStreamWriter.cs
@@ -61,6 +61,10 @@ namespace streamlas
             writer.Write(point.format);
             writer.Write(lasConstants.PointSize[point.format]);
 
+            for (int i = 0; i < 24; i++) writer.Write((byte)0);
+            for (int i = 0; i < 3; i++) writer.Write(reader.scale[i]);
+            for (int i = 0; i < 3; i++) writer.Write(reader.offset[i]);
+
             while (writer.BaseStream.Position != offset_to_points) writer.Write((byte)0);
         }
 

--- a/source/lasStreamWriter.cs
+++ b/source/lasStreamWriter.cs
@@ -36,7 +36,10 @@ namespace streamlas
             writer.Write((byte)1);
             writer.Write(reader.VersionMinor);
 
-            for (int i = 0; i < 64; i++) writer.Write((byte)0);
+            writer.Write(Encoding.ASCII.GetBytes(reader.SystemIdentifier));
+            while (writer.BaseStream.Position < 58) writer.Write('\0');
+
+            for (int i = 0; i < 32; i++) writer.Write((byte)0);
             writer.Write((UInt16)DateTime.Now.DayOfYear);
             writer.Write((UInt16)DateTime.Now.Year);
 

--- a/source/lasStreamWriter.cs
+++ b/source/lasStreamWriter.cs
@@ -10,6 +10,7 @@ namespace streamlas
         private UInt64 count = 0;
         private byte point_format;
         private byte version_minor;
+        private UInt64[] return_counts = new UInt64[15];
 
         public lasStreamWriter(lasStreamReader reader, lasPointRecord point, string path)
         {
@@ -59,6 +60,7 @@ namespace streamlas
         {
             writer.Write(point.raw_data);
             count++;
+            return_counts[point.ReturnNumber - 1]++;
         }
 
         public void Dispose() 
@@ -66,13 +68,17 @@ namespace streamlas
             if (point_format < 6)
             {
                 writer.BaseStream.Position = 107;
-                writer.Write((uint)count);
+                writer.Write((UInt32)count);
+
+                for (int i = 0; i < 5; i++) writer.Write((UInt32)return_counts[i]);
             }
             
             if (version_minor > 3)
             {
                 writer.BaseStream.Position = 247;
                 writer.Write(count);
+
+                for (int i = 0; i < 15; i++) writer.Write(return_counts[i]);
             }
 
             writer.Dispose(); 

--- a/source/lasStreamWriter.cs
+++ b/source/lasStreamWriter.cs
@@ -65,7 +65,7 @@ namespace streamlas
 
             for (int i = 0; i < 4; i++) writer.Write((byte)0);
             writer.Write(point.format);
-            writer.Write(lasConstants.PointSize[point.format]);
+            writer.Write((UInt16)point.raw_data.Length);
 
             for (int i = 0; i < 24; i++) writer.Write((byte)0);
             for (int i = 0; i < 3; i++) writer.Write(reader.scale[i]);
@@ -109,7 +109,7 @@ namespace streamlas
                     writer.Dispose();
                     File.Delete(file_name);
                     throw new IOException("More points than UINT32_MAX written to file;" +
-                        "cannot be supported in legacy mode with Point Format " + point_format);
+                        " unsupported in legacy mode using Point Format " + point_format);
                 }
 
                 writer.BaseStream.Position = 107;

--- a/source/lasStreamWriter.cs
+++ b/source/lasStreamWriter.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace streamlas
@@ -10,6 +12,7 @@ namespace streamlas
         private byte point_format;
         private byte version_minor;
         private UInt32 offset_to_points;
+        private HashSet<UInt16> src_ids = new HashSet<ushort>();
 
         private UInt64 count = 0;
         private UInt64[] return_counts = new UInt64[15];
@@ -66,6 +69,7 @@ namespace streamlas
             writer.Write(point.raw_data);
             count++;
             return_counts[point.ReturnNumber - 1]++;
+            src_ids.Add(point.SourceID);
 
             min_coords[0] = (min_coords[0] < point.X) ? min_coords[0] : point.X;
             min_coords[1] = (min_coords[1] < point.Y) ? min_coords[1] : point.Y;
@@ -78,6 +82,12 @@ namespace streamlas
 
         public void Dispose()
         {
+
+            if (src_ids.Count == 1)
+            {
+                writer.BaseStream.Position = 4;
+                writer.Write(src_ids.First());
+            }
 
             if (point_format < 6)
             {

--- a/source/lasStreamWriter.cs
+++ b/source/lasStreamWriter.cs
@@ -17,8 +17,13 @@ namespace streamlas
             version_minor = reader.VersionMinor;
 
             writer = new BinaryWriter(File.Create(path));
-            writer.Write(Encoding.ASCII.GetBytes("LASF"));            
-            
+            WriteHeader(reader, point);
+        }
+
+        private void WriteHeader(lasStreamReader reader, lasPointRecord point)
+        {
+            writer.Write(Encoding.ASCII.GetBytes("LASF"));
+
             for (int i = 0; i < 20; i++) writer.Write((byte)0);
             writer.Write((byte)1);
             writer.Write(reader.VersionMinor);

--- a/source/lasStreamWriter.cs
+++ b/source/lasStreamWriter.cs
@@ -24,7 +24,9 @@ namespace streamlas
         {
             writer.Write(Encoding.ASCII.GetBytes("LASF"));
 
-            for (int i = 0; i < 4; i++) writer.Write((byte)0);
+            for (int i = 0; i < 2; i++) writer.Write((byte)0);
+
+            writer.Write(reader.global_encoding);
 
             writer.Write(reader.GUID1);
             writer.Write(reader.GUID2);

--- a/source/lasStreamWriter.cs
+++ b/source/lasStreamWriter.cs
@@ -9,10 +9,12 @@ namespace streamlas
         internal BinaryWriter writer;
         private UInt64 count = 0;
         private byte point_format;
+        private byte version_minor;
 
         public lasStreamWriter(lasStreamReader reader, lasPointRecord point, string path)
         {
             point_format = point.format;
+            version_minor = reader.VersionMinor;
 
             writer = new BinaryWriter(File.Create(path));
             writer.Write(Encoding.ASCII.GetBytes("LASF"));            
@@ -45,7 +47,8 @@ namespace streamlas
                 writer.BaseStream.Position = 107;
                 writer.Write((uint)count);
             }
-            else
+            
+            if (version_minor > 3)
             {
                 writer.BaseStream.Position = 247;
                 writer.Write(count);

--- a/source/lasStreamWriter.cs
+++ b/source/lasStreamWriter.cs
@@ -8,7 +8,10 @@ namespace streamlas
 {
     public class lasStreamWriter : IDisposable
     {
+        
         internal BinaryWriter writer;
+        internal string file_name;
+        
         private byte point_format;
         private byte version_minor;
         private UInt32 offset_to_points;
@@ -27,6 +30,7 @@ namespace streamlas
             version_minor = reader.VersionMinor;
             offset_to_points = lasConstants.HeaderSize[reader.VersionMinor - 1];
 
+            file_name = path;
             writer = new BinaryWriter(File.Create(path));
             WriteHeader(reader, point);
         }
@@ -103,6 +107,7 @@ namespace streamlas
                 if (count > UInt32.MaxValue)
                 {
                     writer.Dispose();
+                    File.Delete(file_name);
                     throw new IOException("More points than UINT32_MAX written to file;" +
                         "cannot be supported in legacy mode with Point Format " + point_format);
                 }

--- a/source/lasStreamWriter.cs
+++ b/source/lasStreamWriter.cs
@@ -14,7 +14,6 @@ namespace streamlas
         
         private byte point_format;
         private byte version_minor;
-        private UInt32 offset_to_points;
         private HashSet<UInt16> src_ids = new HashSet<ushort>();
 
         private UInt64 count = 0;
@@ -28,7 +27,6 @@ namespace streamlas
         {
             point_format = point.format;
             version_minor = reader.VersionMinor;
-            offset_to_points = lasConstants.HeaderSize[reader.VersionMinor - 1];
 
             file_name = path;
             writer = new BinaryWriter(File.Create(path));
@@ -61,7 +59,7 @@ namespace streamlas
             writer.Write((UInt16)DateTime.Now.Year);
 
             writer.Write(lasConstants.HeaderSize[reader.VersionMinor - 1]);
-            writer.Write(offset_to_points);
+            writer.Write((UInt32)lasConstants.HeaderSize[reader.VersionMinor - 1]);
 
             for (int i = 0; i < 4; i++) writer.Write((byte)0);
             writer.Write(point.format);
@@ -71,7 +69,7 @@ namespace streamlas
             for (int i = 0; i < 3; i++) writer.Write(reader.scale[i]);
             for (int i = 0; i < 3; i++) writer.Write(reader.offset[i]);
 
-            while (writer.BaseStream.Position != offset_to_points) writer.Write((byte)0);
+            while (writer.BaseStream.Position != lasConstants.HeaderSize[reader.VersionMinor - 1]) writer.Write((byte)0);
         }
 
         public void WritePoint(lasPointRecord point)

--- a/tests/Reading/Header.cs
+++ b/tests/Reading/Header.cs
@@ -156,8 +156,8 @@ namespace Reading
                 {
                     for (int i = 0; i < 3; i++)
                     {
-                        Assert.AreEqual(lr.MinimumXYZ[i], info.MinCoords[i]);
-                        Assert.AreEqual(lr.MaximumXYZ[i], info.MaxCoords[i]);
+                        Assert.AreEqual(info.MinCoords[i], lr.MinimumXYZ[i]);
+                        Assert.AreEqual(info.MaxCoords[i], lr.MaximumXYZ[i]);
                     }
                 }
             }

--- a/tests/Reading/Header.cs
+++ b/tests/Reading/Header.cs
@@ -10,11 +10,11 @@ namespace Reading
         [TestMethod]
         public void FileSourceID()
         {
-            foreach (var file in TestData.BaseFiles)
+            foreach (var info in TestData.BaseFiles)
             {
-                using (lasStreamReader lr = new lasStreamReader(file.FileName))
+                using (lasStreamReader lr = new lasStreamReader(info.FileName))
                 {
-                    Assert.AreEqual(file.SourceID, lr.FileSourceID);
+                    Assert.AreEqual(info.SourceID, lr.FileSourceID);
                 }
             }
         }
@@ -22,14 +22,14 @@ namespace Reading
         [TestMethod]
         public void ProjectID()
         {
-            foreach (var file in TestData.BaseFiles)
+            foreach (var info in TestData.BaseFiles)
             {
-                using (lasStreamReader lr = new lasStreamReader(file.FileName))
+                using (lasStreamReader lr = new lasStreamReader(info.FileName))
                 {
-                    Assert.AreEqual(file.GUID1, lr.GUID1);
-                    Assert.AreEqual(file.GUID2, lr.GUID2);
-                    Assert.AreEqual(file.GUID3, lr.GUID3);
-                    for (int i = 0; i < 8; i++) Assert.AreEqual(file.GUID4[i], lr.GUID4[i]);
+                    Assert.AreEqual(info.GUID1, lr.GUID1);
+                    Assert.AreEqual(info.GUID2, lr.GUID2);
+                    Assert.AreEqual(info.GUID3, lr.GUID3);
+                    for (int i = 0; i < 8; i++) Assert.AreEqual(info.GUID4[i], lr.GUID4[i]);
                 }
             }
         }
@@ -37,11 +37,11 @@ namespace Reading
         [TestMethod]
         public void SystemIdentifier()
         {
-            foreach (var file in TestData.BaseFiles)
+            foreach (var info in TestData.BaseFiles)
             {
-                using (lasStreamReader lr = new lasStreamReader(file.FileName))
+                using (lasStreamReader lr = new lasStreamReader(info.FileName))
                 {
-                    Assert.AreEqual(file.SystemIdentifier, lr.SystemIdentifier);
+                    Assert.AreEqual(info.SystemIdentifier, lr.SystemIdentifier);
                 }
             }
         }
@@ -49,11 +49,11 @@ namespace Reading
         [TestMethod]
         public void GeneratingSoftware()
         {
-            foreach (var file in TestData.BaseFiles)
+            foreach (var info in TestData.BaseFiles)
             {
-                using (lasStreamReader lr = new lasStreamReader(file.FileName))
+                using (lasStreamReader lr = new lasStreamReader(info.FileName))
                 {
-                    Assert.AreEqual(file.GeneratingSoftware, lr.GeneratingSoftware);
+                    Assert.AreEqual(info.GeneratingSoftware, lr.GeneratingSoftware);
                 }
             }
         }
@@ -61,12 +61,12 @@ namespace Reading
         [TestMethod]
         public void CreationDate()
         {
-            foreach (var file in TestData.BaseFiles)
+            foreach (var info in TestData.BaseFiles)
             {
-                using (lasStreamReader lr = new lasStreamReader(file.FileName))
+                using (lasStreamReader lr = new lasStreamReader(info.FileName))
                 {
-                    Assert.AreEqual(file.FileCreationDay, lr.FileCreationDayOfYear);
-                    Assert.AreEqual(file.FileCreationYear, lr.FileCreationYear);
+                    Assert.AreEqual(info.FileCreationDay, lr.FileCreationDayOfYear);
+                    Assert.AreEqual(info.FileCreationYear, lr.FileCreationYear);
                 }
             }
         }
@@ -74,11 +74,11 @@ namespace Reading
         [TestMethod]
         public void VersionMinor()
         {
-            foreach (var file in TestData.BaseFiles)
+            foreach (var info in TestData.BaseFiles)
             {
-                using (lasStreamReader lr = new lasStreamReader(file.FileName))
+                using (lasStreamReader lr = new lasStreamReader(info.FileName))
                 {
-                    Assert.AreEqual(file.VersionMinor, lr.VersionMinor);
+                    Assert.AreEqual(info.VersionMinor, lr.VersionMinor);
                 }
             }
         }
@@ -86,12 +86,12 @@ namespace Reading
         [TestMethod]
         public void Timestamps()
         {
-            foreach (var file in TestData.BaseFiles)
+            foreach (var info in TestData.BaseFiles)
             {
-                using (lasStreamReader lr = new lasStreamReader(file.FileName))
+                using (lasStreamReader lr = new lasStreamReader(info.FileName))
                 {
-                    Assert.AreEqual(file.HasTimestamps, lr.HasTimestamps);
-                    Assert.AreEqual(file.AdjustedGPSTime, lr.AdjustedGPSTime);
+                    Assert.AreEqual(info.HasTimestamps, lr.HasTimestamps);
+                    Assert.AreEqual(info.AdjustedGPSTime, lr.AdjustedGPSTime);
                 }
             }
         }
@@ -99,11 +99,11 @@ namespace Reading
         [TestMethod]
         public void SyntheticReturns()
         {
-            foreach (var file in TestData.BaseFiles)
+            foreach (var info in TestData.BaseFiles)
             {
-                using (lasStreamReader lr = new lasStreamReader(file.FileName))
+                using (lasStreamReader lr = new lasStreamReader(info.FileName))
                 {
-                    Assert.AreEqual(file.SyntheticReturns, lr.SyntheticReturns);
+                    Assert.AreEqual(info.SyntheticReturns, lr.SyntheticReturns);
                 }
             }
         }
@@ -111,11 +111,11 @@ namespace Reading
         [TestMethod]
         public void PointFormat()
         {
-            foreach (var file in TestData.BaseFiles)
+            foreach (var info in TestData.BaseFiles)
             {
-                using (lasStreamReader lr = new lasStreamReader(file.FileName))
+                using (lasStreamReader lr = new lasStreamReader(info.FileName))
                 {
-                    Assert.AreEqual(file.PointFormat, lr.PointFormat);
+                    Assert.AreEqual(info.PointFormat, lr.PointFormat);
                 }
             }
         }
@@ -123,11 +123,11 @@ namespace Reading
         [TestMethod]
         public void PointCount()
         {
-            foreach (var file in TestData.BaseFiles)
+            foreach (var info in TestData.BaseFiles)
             {
-                using (lasStreamReader lr = new lasStreamReader(file.FileName))
+                using (lasStreamReader lr = new lasStreamReader(info.FileName))
                 {
-                    Assert.AreEqual(file.PointCount, lr.PointCount);
+                    Assert.AreEqual(info.PointCount, lr.PointCount);
                 }
             }
         }
@@ -135,13 +135,13 @@ namespace Reading
         [TestMethod]
         public void PointsByReturn()
         {
-            foreach (var file in TestData.BaseFiles)
+            foreach (var info in TestData.BaseFiles)
             {
-                using (lasStreamReader lr = new lasStreamReader(file.FileName))
+                using (lasStreamReader lr = new lasStreamReader(info.FileName))
                 {
                     for (int i = 0; i < 15; i++)
                     {
-                        Assert.AreEqual(file.NumberPointsByReturn[i], lr.NumberPointsByReturn[i]);
+                        Assert.AreEqual(info.NumberPointsByReturn[i], lr.NumberPointsByReturn[i]);
                     }
                 }
             }
@@ -150,14 +150,14 @@ namespace Reading
         [TestMethod]
         public void CoordinateExtents()
         {
-            foreach (var file in TestData.BaseFiles)
+            foreach (var info in TestData.BaseFiles)
             {
-                using (lasStreamReader lr = new lasStreamReader(file.FileName))
+                using (lasStreamReader lr = new lasStreamReader(info.FileName))
                 {
                     for (int i = 0; i < 3; i++)
                     {
-                        Assert.AreEqual(lr.MinimumXYZ[i], file.MinCoords[i]);
-                        Assert.AreEqual(lr.MaximumXYZ[i], file.MaxCoords[i]);
+                        Assert.AreEqual(lr.MinimumXYZ[i], info.MinCoords[i]);
+                        Assert.AreEqual(lr.MaximumXYZ[i], info.MaxCoords[i]);
                     }
                 }
             }

--- a/tests/Reading/Points.cs
+++ b/tests/Reading/Points.cs
@@ -11,9 +11,9 @@ namespace Reading
         [TestMethod]
         public void Coordinates()
         {
-            foreach (var file in TestData.BaseFiles)
+            foreach (var info in TestData.BaseFiles)
             {
-                using (lasStreamReader lr = new lasStreamReader(file.FileName))
+                using (lasStreamReader lr = new lasStreamReader(info.FileName))
                 {
                     var ref_pts = TestData.BaseFilePoints[lr.PointFormat];
                     lasPointRecord pt = new lasPointRecord(lr);
@@ -32,9 +32,9 @@ namespace Reading
         [TestMethod]
         public void Intensity()
         {
-            foreach (var file in TestData.BaseFiles)
+            foreach (var info in TestData.BaseFiles)
             {
-                using (lasStreamReader lr = new lasStreamReader(file.FileName))
+                using (lasStreamReader lr = new lasStreamReader(info.FileName))
                 {
                     var ref_pts = TestData.BaseFilePoints[lr.PointFormat];
                     lasPointRecord pt = new lasPointRecord(lr);
@@ -51,9 +51,9 @@ namespace Reading
         [TestMethod]
         public void Returns()
         {
-            foreach (var file in TestData.BaseFiles)
+            foreach (var info in TestData.BaseFiles)
             {
-                using (lasStreamReader lr = new lasStreamReader(file.FileName))
+                using (lasStreamReader lr = new lasStreamReader(info.FileName))
                 {
                     var ref_pts = TestData.BaseFilePoints[lr.PointFormat];
                     lasPointRecord pt = new lasPointRecord(lr);
@@ -71,9 +71,9 @@ namespace Reading
         [TestMethod]
         public void Classification()
         {
-            foreach (var file in TestData.BaseFiles)
+            foreach (var info in TestData.BaseFiles)
             {
-                using (lasStreamReader lr = new lasStreamReader(file.FileName))
+                using (lasStreamReader lr = new lasStreamReader(info.FileName))
                 {
                     var ref_pts = TestData.BaseFilePoints[lr.PointFormat];
                     lasPointRecord pt = new lasPointRecord(lr);
@@ -90,9 +90,9 @@ namespace Reading
         [TestMethod]
         public void BitFlags()
         {
-            foreach (var file in TestData.BaseFiles)
+            foreach (var info in TestData.BaseFiles)
             {
-                using (lasStreamReader lr = new lasStreamReader(file.FileName))
+                using (lasStreamReader lr = new lasStreamReader(info.FileName))
                 {
                     var ref_pts = TestData.BaseFilePoints[lr.PointFormat];
                     lasPointRecord pt = new lasPointRecord(lr);
@@ -120,9 +120,9 @@ namespace Reading
         [TestMethod]
         public void ScannerChannel()
         {
-            foreach (var file in TestData.BaseFiles)
+            foreach (var info in TestData.BaseFiles)
             {
-                using (lasStreamReader lr = new lasStreamReader(file.FileName))
+                using (lasStreamReader lr = new lasStreamReader(info.FileName))
                 {
                     var ref_pts = TestData.BaseFilePoints[lr.PointFormat];
                     lasPointRecord pt = new lasPointRecord(lr);
@@ -144,9 +144,9 @@ namespace Reading
         [TestMethod]
         public void UserData()
         {
-            foreach (var file in TestData.BaseFiles)
+            foreach (var info in TestData.BaseFiles)
             {
-                using (lasStreamReader lr = new lasStreamReader(file.FileName))
+                using (lasStreamReader lr = new lasStreamReader(info.FileName))
                 {
                     var ref_pts = TestData.BaseFilePoints[lr.PointFormat];
                     lasPointRecord pt = new lasPointRecord(lr);
@@ -163,9 +163,9 @@ namespace Reading
         [TestMethod]
         public void ScanAngle()
         {
-            foreach (var file in TestData.BaseFiles)
+            foreach (var info in TestData.BaseFiles)
             {
-                using (lasStreamReader lr = new lasStreamReader(file.FileName))
+                using (lasStreamReader lr = new lasStreamReader(info.FileName))
                 {
                     var ref_pts = TestData.BaseFilePoints[lr.PointFormat];
                     lasPointRecord pt = new lasPointRecord(lr);
@@ -184,9 +184,9 @@ namespace Reading
         [TestMethod]
         public void SourceID()
         {
-            foreach (var file in TestData.BaseFiles)
+            foreach (var info in TestData.BaseFiles)
             {
-                using (lasStreamReader lr = new lasStreamReader(file.FileName))
+                using (lasStreamReader lr = new lasStreamReader(info.FileName))
                 {
                     var ref_pts = TestData.BaseFilePoints[lr.PointFormat];
                     lasPointRecord pt = new lasPointRecord(lr);
@@ -203,9 +203,9 @@ namespace Reading
         [TestMethod]
         public void Timestamps()
         {
-            foreach (var file in TestData.BaseFiles)
+            foreach (var info in TestData.BaseFiles)
             {
-                using (lasStreamReader lr = new lasStreamReader(file.FileName))
+                using (lasStreamReader lr = new lasStreamReader(info.FileName))
                 {
                     var ref_pts = TestData.BaseFilePoints[lr.PointFormat];
                     lasPointRecord pt = new lasPointRecord(lr);

--- a/tests/TestData.cs
+++ b/tests/TestData.cs
@@ -61,6 +61,7 @@ namespace tests
         internal static readonly List<ErrorFileInfo> ErrorFiles;
         internal static readonly List<BaseFileInfo> BaseFiles;
         internal static readonly Dictionary<byte, List<PointInfo>> BaseFilePoints;
+        internal static readonly string WritePath;
 
         internal static List<ErrorFileInfo> GetErrorFileInfo(string data_dir, string json_file)
         {
@@ -104,6 +105,8 @@ namespace tests
                 string point_file = data_dir + string.Format("PointFormat_{0:00}.json", pfmt);
                 BaseFilePoints.Add(pfmt, GetPointInfo(point_file));
             }
+
+            WritePath = "../../../Data/Writing/";
         }
     }
 }

--- a/tests/TestData.cs
+++ b/tests/TestData.cs
@@ -108,5 +108,10 @@ namespace tests
 
             WritePath = "../../../Data/Writing/";
         }
+
+        internal static string WriteTestPath(BaseFileInfo test_file)
+        {
+            return Path.Combine(WritePath, Path.GetFileName(test_file.FileName));
+        }
     }
 }

--- a/tests/Writing/Header.cs
+++ b/tests/Writing/Header.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using streamlas;
 using tests;
 
@@ -42,6 +43,20 @@ namespace Writing
                 using (lasStreamReader lr = new lasStreamReader(test_path))
                 {
                     Assert.AreEqual(file.PointCount, lr.PointCount);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void CreationDate()
+        {
+            foreach (var file in TestData.BaseFiles)
+            {
+                string test_path = Utility.WritePath(file);
+                using (lasStreamReader lr = new lasStreamReader(test_path))
+                {
+                    Assert.AreEqual(DateTime.Now.DayOfYear, lr.FileCreationDayOfYear);
+                    Assert.AreEqual(DateTime.Now.Year, lr.FileCreationYear);
                 }
             }
         }

--- a/tests/Writing/Header.cs
+++ b/tests/Writing/Header.cs
@@ -45,7 +45,8 @@ namespace Writing
                 string in_path = TestData.WriteTestPath(info);
                 using (lasStreamReader lr = new lasStreamReader(in_path))
                 {
-                    Assert.AreEqual(info.SystemIdentifier, lr.SystemIdentifier);
+                    if (info.SystemIdentifier == "OTHER") Assert.AreEqual(info.SystemIdentifier, lr.SystemIdentifier);
+                    else Assert.AreEqual("MODIFICATION", lr.SystemIdentifier);
                 }
             }
         }

--- a/tests/Writing/Header.cs
+++ b/tests/Writing/Header.cs
@@ -38,6 +38,20 @@ namespace Writing
         }
 
         [TestMethod]
+        public void Timestamps()
+        {
+            foreach (var info in TestData.BaseFiles)
+            {
+                string in_path = TestData.WriteTestPath(info);
+                using (lasStreamReader lr = new lasStreamReader(in_path))
+                {
+                    Assert.AreEqual(info.HasTimestamps, lr.HasTimestamps);
+                    Assert.AreEqual(info.AdjustedGPSTime, lr.AdjustedGPSTime);
+                }
+            }
+        }
+
+        [TestMethod]
         public void PointFormat()
         {
             foreach (var info in TestData.BaseFiles)

--- a/tests/Writing/Header.cs
+++ b/tests/Writing/Header.cs
@@ -117,6 +117,22 @@ namespace Writing
         }
 
         [TestMethod]
+        public void PointsByReturn()
+        {
+            foreach (var info in TestData.BaseFiles)
+            {
+                string in_path = TestData.WriteTestPath(info);
+                using (lasStreamReader lr = new lasStreamReader(in_path))
+                {
+                    for (int i = 0; i < 15; i++)
+                    {
+                        Assert.AreEqual(info.NumberPointsByReturn[i], lr.NumberPointsByReturn[i]);
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
         public void CreationDate()
         {
             foreach (var info in TestData.BaseFiles)

--- a/tests/Writing/Header.cs
+++ b/tests/Writing/Header.cs
@@ -83,5 +83,24 @@ namespace Writing
                 }
             }
         }
+
+        [TestMethod]
+        public void PointCounts()
+        {
+            foreach (var file in TestData.BaseFiles)
+            {
+                string test_path = Utility.WritePath(file);
+                using (BinaryReader r = new BinaryReader(File.OpenRead(test_path)))
+                {
+                    r.ReadBytes(107);
+                    if (file.PointFormat < 6) Assert.AreEqual(file.PointCount, r.ReadUInt32());
+                    else
+                    {
+                        r.ReadBytes(140);
+                        Assert.AreEqual(file.PointCount, r.ReadUInt64());
+                    }
+                }
+            }
+        }
     }
 }

--- a/tests/Writing/Header.cs
+++ b/tests/Writing/Header.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using streamlas;
 using tests;
+using System;
 
 namespace Writing
 {
@@ -46,6 +47,23 @@ namespace Writing
                 {
                     r.ReadBytes(104);
                     Assert.AreEqual(file.PointFormat, r.ReadByte());
+                }
+            }
+        }
+
+        [TestMethod]
+        public void HeaderSizeAndOffset()
+        {
+            foreach (var file in TestData.BaseFiles)
+            {
+                UInt16[] HeaderSize = { 227, 227, 235, 375 };
+
+                string test_path = Utility.WritePath(file);
+                using (BinaryReader r = new BinaryReader(File.OpenRead(test_path)))
+                {
+                    r.ReadBytes(94);
+                    Assert.AreEqual(HeaderSize[file.VersionMinor - 1], r.ReadUInt16());
+                    Assert.AreEqual(HeaderSize[file.VersionMinor - 1], r.ReadUInt32());
                 }
             }
         }

--- a/tests/Writing/Header.cs
+++ b/tests/Writing/Header.cs
@@ -20,5 +20,20 @@ namespace Writing
                 }
             }
         }
+
+        [TestMethod]
+        public void Version()
+        {
+            foreach (var file in TestData.BaseFiles)
+            {
+                string test_path = Utility.WritePath(file);
+                using (BinaryReader r = new BinaryReader(File.OpenRead(test_path)))
+                {
+                    r.ReadBytes(24);
+                    Assert.AreEqual((byte)1, r.ReadByte());
+                    Assert.AreEqual(file.VersionMinor, r.ReadByte());
+                }
+            }
+        }
     }
 }

--- a/tests/Writing/Header.cs
+++ b/tests/Writing/Header.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using streamlas;
+using tests;
+
+namespace Writing
+{
+    [TestClass]
+    public class Header
+    {
+        [TestMethod]
+        public void FileSignature()
+        {
+            foreach (var file in TestData.BaseFiles)
+            {
+                string test_path = Utility.WritePath(file);
+                using (BinaryReader r = new BinaryReader(File.OpenRead(test_path)))
+                {
+                    Assert.AreEqual("LASF", new string(r.ReadChars(4)));
+                }
+            }
+        }
+    }
+}

--- a/tests/Writing/Header.cs
+++ b/tests/Writing/Header.cs
@@ -13,7 +13,7 @@ namespace Writing
         {
             foreach (var file in TestData.BaseFiles)
             {
-                string test_path = Utility.WritePath(file);
+                string test_path = TestData.WriteTestPath(file);
                 using (lasStreamReader lr = new lasStreamReader(test_path))
                 {
                     Assert.AreEqual(file.VersionMinor, lr.VersionMinor);
@@ -26,7 +26,7 @@ namespace Writing
         {
             foreach (var file in TestData.BaseFiles)
             {
-                string test_path = Utility.WritePath(file);
+                string test_path = TestData.WriteTestPath(file);
                 using (lasStreamReader lr = new lasStreamReader(test_path))
                 {
                     Assert.AreEqual(file.PointFormat, lr.PointFormat);
@@ -39,7 +39,7 @@ namespace Writing
         {
             foreach (var file in TestData.BaseFiles)
             {
-                string test_path = Utility.WritePath(file);
+                string test_path = TestData.WriteTestPath(file);
                 using (lasStreamReader lr = new lasStreamReader(test_path))
                 {
                     Assert.AreEqual(file.PointCount, lr.PointCount);
@@ -52,7 +52,7 @@ namespace Writing
         {
             foreach (var file in TestData.BaseFiles)
             {
-                string test_path = Utility.WritePath(file);
+                string test_path = TestData.WriteTestPath(file);
                 using (lasStreamReader lr = new lasStreamReader(test_path))
                 {
                     Assert.AreEqual(DateTime.Now.DayOfYear, lr.FileCreationDayOfYear);

--- a/tests/Writing/Header.cs
+++ b/tests/Writing/Header.cs
@@ -1,8 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.IO;
 using streamlas;
 using tests;
-using System;
 
 namespace Writing
 {
@@ -10,29 +8,14 @@ namespace Writing
     public class Header
     {
         [TestMethod]
-        public void FileSignature()
+        public void VersionMinor()
         {
             foreach (var file in TestData.BaseFiles)
             {
                 string test_path = Utility.WritePath(file);
-                using (BinaryReader r = new BinaryReader(File.OpenRead(test_path)))
+                using (lasStreamReader lr = new lasStreamReader(test_path))
                 {
-                    Assert.AreEqual("LASF", new string(r.ReadChars(4)));
-                }
-            }
-        }
-
-        [TestMethod]
-        public void Version()
-        {
-            foreach (var file in TestData.BaseFiles)
-            {
-                string test_path = Utility.WritePath(file);
-                using (BinaryReader r = new BinaryReader(File.OpenRead(test_path)))
-                {
-                    r.ReadBytes(24);
-                    Assert.AreEqual((byte)1, r.ReadByte());
-                    Assert.AreEqual(file.VersionMinor, r.ReadByte());
+                    Assert.AreEqual(file.VersionMinor, lr.VersionMinor);
                 }
             }
         }
@@ -43,43 +26,9 @@ namespace Writing
             foreach (var file in TestData.BaseFiles)
             {
                 string test_path = Utility.WritePath(file);
-                using (BinaryReader r = new BinaryReader(File.OpenRead(test_path)))
+                using (lasStreamReader lr = new lasStreamReader(test_path))
                 {
-                    r.ReadBytes(104);
-                    Assert.AreEqual(file.PointFormat, r.ReadByte());
-                }
-            }
-        }
-
-        [TestMethod]
-        public void HeaderSizeAndOffset()
-        {
-            foreach (var file in TestData.BaseFiles)
-            {
-                UInt16[] HeaderSize = { 227, 227, 235, 375 };
-
-                string test_path = Utility.WritePath(file);
-                using (BinaryReader r = new BinaryReader(File.OpenRead(test_path)))
-                {
-                    r.ReadBytes(94);
-                    Assert.AreEqual(HeaderSize[file.VersionMinor - 1], r.ReadUInt16());
-                    Assert.AreEqual(HeaderSize[file.VersionMinor - 1], r.ReadUInt32());
-                }
-            }
-        }
-
-        [TestMethod]
-        public void PointSize()
-        {
-            foreach (var file in TestData.BaseFiles)
-            {
-                UInt16[] PointSize = { 20, 28, 26, 34, 57, 63, 30, 36, 38, 59, 67 };
-
-                string test_path = Utility.WritePath(file);
-                using (BinaryReader r = new BinaryReader(File.OpenRead(test_path)))
-                {
-                    r.ReadBytes(105);
-                    Assert.AreEqual(PointSize[file.PointFormat], r.ReadUInt16());
+                    Assert.AreEqual(file.PointFormat, lr.PointFormat);
                 }
             }
         }
@@ -90,15 +39,9 @@ namespace Writing
             foreach (var file in TestData.BaseFiles)
             {
                 string test_path = Utility.WritePath(file);
-                using (BinaryReader r = new BinaryReader(File.OpenRead(test_path)))
+                using (lasStreamReader lr = new lasStreamReader(test_path))
                 {
-                    r.ReadBytes(107);
-                    if (file.PointFormat < 6) Assert.AreEqual(file.PointCount, r.ReadUInt32());
-                    else
-                    {
-                        r.ReadBytes(140);
-                        Assert.AreEqual(file.PointCount, r.ReadUInt64());
-                    }
+                    Assert.AreEqual(file.PointCount, lr.PointCount);
                 }
             }
         }

--- a/tests/Writing/Header.cs
+++ b/tests/Writing/Header.cs
@@ -156,8 +156,8 @@ namespace Writing
                 {
                     for (int i = 0; i < 3; i++)
                     {
-                        Assert.AreEqual(info.MinCoords[i], lr.MinimumXYZ[i]);
-                        Assert.AreEqual(info.MaxCoords[i], lr.MaximumXYZ[i]);
+                        Assert.AreEqual(info.MinCoords[i], lr.MinimumXYZ[i], 1e-6);
+                        Assert.AreEqual(info.MaxCoords[i], lr.MaximumXYZ[i], 1e-6);
                     }
                 }
             }

--- a/tests/Writing/Header.cs
+++ b/tests/Writing/Header.cs
@@ -78,9 +78,8 @@ namespace Writing
                 string test_path = Utility.WritePath(file);
                 using (BinaryReader r = new BinaryReader(File.OpenRead(test_path)))
                 {
-                    r.ReadBytes(94);
+                    r.ReadBytes(105);
                     Assert.AreEqual(PointSize[file.PointFormat], r.ReadUInt16());
-                    Assert.AreEqual(PointSize[file.PointFormat], r.ReadUInt32());
                 }
             }
         }

--- a/tests/Writing/Header.cs
+++ b/tests/Writing/Header.cs
@@ -38,6 +38,19 @@ namespace Writing
         }
 
         [TestMethod]
+        public void GeneratingSoftware()
+        {
+            foreach (var info in TestData.BaseFiles)
+            {
+                string in_path = TestData.WriteTestPath(info);
+                using (lasStreamReader lr = new lasStreamReader(in_path))
+                {
+                    Assert.AreEqual("streamlas - .NET LAS IO Library", lr.GeneratingSoftware);
+                }
+            }
+        }
+
+        [TestMethod]
         public void VersionMinor()
         {
             foreach (var info in TestData.BaseFiles)

--- a/tests/Writing/Header.cs
+++ b/tests/Writing/Header.cs
@@ -11,15 +11,15 @@ namespace Writing
         [TestMethod]
         public void ProjectID()
         {
-            foreach (var file in TestData.BaseFiles)
+            foreach (var info in TestData.BaseFiles)
             {
-                string test_path = TestData.WriteTestPath(file);
-                using (lasStreamReader lr = new lasStreamReader(test_path))
+                string in_path = TestData.WriteTestPath(info);
+                using (lasStreamReader lr = new lasStreamReader(in_path))
                 {
-                    Assert.AreEqual(file.GUID1, lr.GUID1);
-                    Assert.AreEqual(file.GUID2, lr.GUID2);
-                    Assert.AreEqual(file.GUID3, lr.GUID3);
-                    for (int i = 0; i < 8; i++) Assert.AreEqual(file.GUID4[i], lr.GUID4[i]);
+                    Assert.AreEqual(info.GUID1, lr.GUID1);
+                    Assert.AreEqual(info.GUID2, lr.GUID2);
+                    Assert.AreEqual(info.GUID3, lr.GUID3);
+                    for (int i = 0; i < 8; i++) Assert.AreEqual(info.GUID4[i], lr.GUID4[i]);
                 }
             }
         }
@@ -27,12 +27,12 @@ namespace Writing
         [TestMethod]
         public void VersionMinor()
         {
-            foreach (var file in TestData.BaseFiles)
+            foreach (var info in TestData.BaseFiles)
             {
-                string test_path = TestData.WriteTestPath(file);
-                using (lasStreamReader lr = new lasStreamReader(test_path))
+                string in_path = TestData.WriteTestPath(info);
+                using (lasStreamReader lr = new lasStreamReader(in_path))
                 {
-                    Assert.AreEqual(file.VersionMinor, lr.VersionMinor);
+                    Assert.AreEqual(info.VersionMinor, lr.VersionMinor);
                 }
             }
         }
@@ -40,12 +40,12 @@ namespace Writing
         [TestMethod]
         public void PointFormat()
         {
-            foreach (var file in TestData.BaseFiles)
+            foreach (var info in TestData.BaseFiles)
             {
-                string test_path = TestData.WriteTestPath(file);
-                using (lasStreamReader lr = new lasStreamReader(test_path))
+                string in_path = TestData.WriteTestPath(info);
+                using (lasStreamReader lr = new lasStreamReader(in_path))
                 {
-                    Assert.AreEqual(file.PointFormat, lr.PointFormat);
+                    Assert.AreEqual(info.PointFormat, lr.PointFormat);
                 }
             }
         }
@@ -53,12 +53,12 @@ namespace Writing
         [TestMethod]
         public void PointCounts()
         {
-            foreach (var file in TestData.BaseFiles)
+            foreach (var info in TestData.BaseFiles)
             {
-                string test_path = TestData.WriteTestPath(file);
-                using (lasStreamReader lr = new lasStreamReader(test_path))
+                string in_path = TestData.WriteTestPath(info);
+                using (lasStreamReader lr = new lasStreamReader(in_path))
                 {
-                    Assert.AreEqual(file.PointCount, lr.PointCount);
+                    Assert.AreEqual(info.PointCount, lr.PointCount);
                 }
             }
         }
@@ -66,10 +66,10 @@ namespace Writing
         [TestMethod]
         public void CreationDate()
         {
-            foreach (var file in TestData.BaseFiles)
+            foreach (var info in TestData.BaseFiles)
             {
-                string test_path = TestData.WriteTestPath(file);
-                using (lasStreamReader lr = new lasStreamReader(test_path))
+                string in_path = TestData.WriteTestPath(info);
+                using (lasStreamReader lr = new lasStreamReader(in_path))
                 {
                     Assert.AreEqual(DateTime.Now.DayOfYear, lr.FileCreationDayOfYear);
                     Assert.AreEqual(DateTime.Now.Year, lr.FileCreationYear);

--- a/tests/Writing/Header.cs
+++ b/tests/Writing/Header.cs
@@ -25,6 +25,19 @@ namespace Writing
         }
 
         [TestMethod]
+        public void SystemIdentifier()
+        {
+            foreach (var info in TestData.BaseFiles)
+            {
+                string in_path = TestData.WriteTestPath(info);
+                using (lasStreamReader lr = new lasStreamReader(in_path))
+                {
+                    Assert.AreEqual(info.SystemIdentifier, lr.SystemIdentifier);
+                }
+            }
+        }
+
+        [TestMethod]
         public void VersionMinor()
         {
             foreach (var info in TestData.BaseFiles)

--- a/tests/Writing/Header.cs
+++ b/tests/Writing/Header.cs
@@ -9,6 +9,22 @@ namespace Writing
     public class Header
     {
         [TestMethod]
+        public void ProjectID()
+        {
+            foreach (var file in TestData.BaseFiles)
+            {
+                string test_path = TestData.WriteTestPath(file);
+                using (lasStreamReader lr = new lasStreamReader(test_path))
+                {
+                    Assert.AreEqual(file.GUID1, lr.GUID1);
+                    Assert.AreEqual(file.GUID2, lr.GUID2);
+                    Assert.AreEqual(file.GUID3, lr.GUID3);
+                    for (int i = 0; i < 8; i++) Assert.AreEqual(file.GUID4[i], lr.GUID4[i]);
+                }
+            }
+        }
+
+        [TestMethod]
         public void VersionMinor()
         {
             foreach (var file in TestData.BaseFiles)

--- a/tests/Writing/Header.cs
+++ b/tests/Writing/Header.cs
@@ -9,6 +9,19 @@ namespace Writing
     public class Header
     {
         [TestMethod]
+        public void FileSourceID()
+        {
+            foreach (var info in TestData.BaseFiles)
+            {
+                string in_path = TestData.WriteTestPath(info);
+                using (lasStreamReader lr = new lasStreamReader(in_path))
+                {
+                    Assert.AreEqual(info.SourceID, lr.FileSourceID);
+                }
+            }
+        }
+
+        [TestMethod]
         public void ProjectID()
         {
             foreach (var info in TestData.BaseFiles)

--- a/tests/Writing/Header.cs
+++ b/tests/Writing/Header.cs
@@ -67,5 +67,22 @@ namespace Writing
                 }
             }
         }
+
+        [TestMethod]
+        public void PointSize()
+        {
+            foreach (var file in TestData.BaseFiles)
+            {
+                UInt16[] PointSize = { 20, 28, 26, 34, 57, 63, 30, 36, 38, 59, 67 };
+
+                string test_path = Utility.WritePath(file);
+                using (BinaryReader r = new BinaryReader(File.OpenRead(test_path)))
+                {
+                    r.ReadBytes(94);
+                    Assert.AreEqual(PointSize[file.PointFormat], r.ReadUInt16());
+                    Assert.AreEqual(PointSize[file.PointFormat], r.ReadUInt32());
+                }
+            }
+        }
     }
 }

--- a/tests/Writing/Header.cs
+++ b/tests/Writing/Header.cs
@@ -35,5 +35,19 @@ namespace Writing
                 }
             }
         }
+
+        [TestMethod]
+        public void PointFormat()
+        {
+            foreach (var file in TestData.BaseFiles)
+            {
+                string test_path = Utility.WritePath(file);
+                using (BinaryReader r = new BinaryReader(File.OpenRead(test_path)))
+                {
+                    r.ReadBytes(104);
+                    Assert.AreEqual(file.PointFormat, r.ReadByte());
+                }
+            }
+        }
     }
 }

--- a/tests/Writing/Header.cs
+++ b/tests/Writing/Header.cs
@@ -52,6 +52,19 @@ namespace Writing
         }
 
         [TestMethod]
+        public void SyntheticReturns()
+        {
+            foreach (var info in TestData.BaseFiles)
+            {
+                string in_path = TestData.WriteTestPath(info);
+                using (lasStreamReader lr = new lasStreamReader(in_path))
+                {
+                    Assert.AreEqual(info.SyntheticReturns, lr.SyntheticReturns);
+                }
+            }
+        }
+
+        [TestMethod]
         public void PointFormat()
         {
             foreach (var info in TestData.BaseFiles)

--- a/tests/Writing/Header.cs
+++ b/tests/Writing/Header.cs
@@ -145,5 +145,22 @@ namespace Writing
                 }
             }
         }
+
+        [TestMethod]
+        public void CoordinateExtents()
+        {
+            foreach (var info in TestData.BaseFiles)
+            {
+                string in_path = TestData.WriteTestPath(info);
+                using (lasStreamReader lr = new lasStreamReader(in_path))
+                {
+                    for (int i = 0; i < 3; i++)
+                    {
+                        Assert.AreEqual(info.MinCoords[i], lr.MinimumXYZ[i]);
+                        Assert.AreEqual(info.MaxCoords[i], lr.MaximumXYZ[i]);
+                    }
+                }
+            }
+        }
     }
 }

--- a/tests/Writing/Points.cs
+++ b/tests/Writing/Points.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using streamlas;
+using System;
 using tests;
 
 namespace Writing
@@ -24,6 +25,210 @@ namespace Writing
                         Assert.AreEqual(ref_pts[i].X, pt.X, 1e-6);
                         Assert.AreEqual(ref_pts[i].Y, pt.Y, 1e-6);
                         Assert.AreEqual(ref_pts[i].Z, pt.Z, 1e-6);
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void Intensity()
+        {
+            foreach (var info in TestData.BaseFiles)
+            {
+                string in_path = TestData.WriteTestPath(info);
+                using (lasStreamReader lr = new lasStreamReader(in_path))
+                {
+                    var ref_pts = TestData.BaseFilePoints[lr.PointFormat];
+                    lasPointRecord pt = new lasPointRecord(lr);
+
+                    for (int i = 0; i < ref_pts.Count; i++)
+                    {
+                        pt.ReadFrom(lr);
+                        Assert.AreEqual(ref_pts[i].Intensity, pt.Intensity);
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void Returns()
+        {
+            foreach (var info in TestData.BaseFiles)
+            {
+                string in_path = TestData.WriteTestPath(info);
+                using (lasStreamReader lr = new lasStreamReader(in_path))
+                {
+                    var ref_pts = TestData.BaseFilePoints[lr.PointFormat];
+                    lasPointRecord pt = new lasPointRecord(lr);
+
+                    for (int i = 0; i < ref_pts.Count; i++)
+                    {
+                        pt.ReadFrom(lr);
+                        Assert.AreEqual(ref_pts[i].Return, pt.ReturnNumber);
+                        Assert.AreEqual(ref_pts[i].NumberReturns, pt.NumberReturns);
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void Classification()
+        {
+            foreach (var info in TestData.BaseFiles)
+            {
+                string in_path = TestData.WriteTestPath(info);
+                using (lasStreamReader lr = new lasStreamReader(in_path))
+                {
+                    var ref_pts = TestData.BaseFilePoints[lr.PointFormat];
+                    lasPointRecord pt = new lasPointRecord(lr);
+
+                    for (int i = 0; i < ref_pts.Count; i++)
+                    {
+                        pt.ReadFrom(lr);
+                        Assert.AreEqual(ref_pts[i].Classification, pt.Classification);
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void BitFlags()
+        {
+            foreach (var info in TestData.BaseFiles)
+            {
+                string in_path = TestData.WriteTestPath(info);
+                using (lasStreamReader lr = new lasStreamReader(in_path))
+                {
+                    var ref_pts = TestData.BaseFilePoints[lr.PointFormat];
+                    lasPointRecord pt = new lasPointRecord(lr);
+
+                    for (int i = 0; i < ref_pts.Count; i++)
+                    {
+                        pt.ReadFrom(lr);
+                        Assert.AreEqual(ref_pts[i].SyntheticFlag, pt.SyntheticFlag);
+                        Assert.AreEqual(ref_pts[i].KeypointFlag, pt.KeypointFlag);
+                        Assert.AreEqual(ref_pts[i].WithheldFlag, pt.WithheldFlag);
+                        Assert.AreEqual(ref_pts[i].ScanDirectionFlag, pt.ScanDirectionFlag);
+                        Assert.AreEqual(ref_pts[i].EdgeOfFlightLineFlag, pt.EdgeOfFlightLineFlag);
+
+                        if (lr.PointFormat < 6)
+                        {
+                            var ex = Assert.Throws<InvalidOperationException>(() => pt.OverlapFlag());
+                            Assert.IsTrue(ex.Message.Contains("Overlap flag not defined for point format"));
+                        }
+                        else Assert.AreEqual(ref_pts[i].OverlapFlag, pt.OverlapFlag());
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void ScannerChannel()
+        {
+            foreach (var info in TestData.BaseFiles)
+            {
+                string in_path = TestData.WriteTestPath(info);
+                using (lasStreamReader lr = new lasStreamReader(in_path))
+                {
+                    var ref_pts = TestData.BaseFilePoints[lr.PointFormat];
+                    lasPointRecord pt = new lasPointRecord(lr);
+
+                    for (int i = 0; i < ref_pts.Count; i++)
+                    {
+                        pt.ReadFrom(lr);
+                        if (lr.PointFormat < 6)
+                        {
+                            var ex = Assert.Throws<InvalidOperationException>(() => pt.ScannerChannel());
+                            Assert.IsTrue(ex.Message.Contains("Scanner Channel field not defined for point format"));
+                        }
+                        else Assert.AreEqual(ref_pts[i].ScannerChannel, pt.ScannerChannel());
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void UserData()
+        {
+            foreach (var info in TestData.BaseFiles)
+            {
+                string in_path = TestData.WriteTestPath(info);
+                using (lasStreamReader lr = new lasStreamReader(in_path))
+                {
+                    var ref_pts = TestData.BaseFilePoints[lr.PointFormat];
+                    lasPointRecord pt = new lasPointRecord(lr);
+
+                    for (int i = 0; i < ref_pts.Count; i++)
+                    {
+                        pt.ReadFrom(lr);
+                        Assert.AreEqual(ref_pts[i].UserData, pt.UserData);
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void ScanAngle()
+        {
+            foreach (var info in TestData.BaseFiles)
+            {
+                string in_path = TestData.WriteTestPath(info);
+                using (lasStreamReader lr = new lasStreamReader(in_path))
+                {
+                    var ref_pts = TestData.BaseFilePoints[lr.PointFormat];
+                    lasPointRecord pt = new lasPointRecord(lr);
+
+                    for (int i = 0; i < ref_pts.Count; i++)
+                    {
+                        pt.ReadFrom(lr);
+                        double test_val = ref_pts[i].ScanAngle * 0.006;
+                        if (lr.PointFormat < 6) Assert.AreEqual(Math.Round(test_val), pt.ScanAngle);
+                        else Assert.AreEqual(test_val, pt.ScanAngle);
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void SourceID()
+        {
+            foreach (var info in TestData.BaseFiles)
+            {
+                string in_path = TestData.WriteTestPath(info);
+                using (lasStreamReader lr = new lasStreamReader(in_path))
+                {
+                    var ref_pts = TestData.BaseFilePoints[lr.PointFormat];
+                    lasPointRecord pt = new lasPointRecord(lr);
+
+                    for (int i = 0; i < ref_pts.Count; i++)
+                    {
+                        pt.ReadFrom(lr);
+                        Assert.AreEqual(ref_pts[i].SourceID, pt.SourceID);
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void Timestamps()
+        {
+            foreach (var info in TestData.BaseFiles)
+            {
+                string in_path = TestData.WriteTestPath(info);
+                using (lasStreamReader lr = new lasStreamReader(in_path))
+                {
+                    var ref_pts = TestData.BaseFilePoints[lr.PointFormat];
+                    lasPointRecord pt = new lasPointRecord(lr);
+
+                    for (int i = 0; i < ref_pts.Count; i++)
+                    {
+                        pt.ReadFrom(lr);
+                        if (!lr.HasTimestamps)
+                        {
+                            var ex = Assert.Throws<InvalidOperationException>(() => pt.Timestamp());
+                            Assert.IsTrue(ex.Message.Contains("Timestamp not stored in point format"));
+                        }
+                        else Assert.AreEqual(ref_pts[i].Timestamp, pt.Timestamp());
                     }
                 }
             }

--- a/tests/Writing/Points.cs
+++ b/tests/Writing/Points.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using streamlas;
+using tests;
+
+namespace Writing
+{
+    [TestClass]
+    public class Points
+    {
+        [TestMethod]
+        public void Coordinates()
+        {
+            foreach (var info in TestData.BaseFiles)
+            {
+                string in_path = TestData.WriteTestPath(info);
+                using (lasStreamReader lr = new lasStreamReader(in_path))
+                {
+                    var ref_pts = TestData.BaseFilePoints[lr.PointFormat];
+                    lasPointRecord pt = new lasPointRecord(lr);
+
+                    for (int i = 0; i < ref_pts.Count; i++)
+                    {
+                        pt.ReadFrom(lr);
+                        Assert.AreEqual(ref_pts[i].X, pt.X, 1e-6);
+                        Assert.AreEqual(ref_pts[i].Y, pt.Y, 1e-6);
+                        Assert.AreEqual(ref_pts[i].Z, pt.Z, 1e-6);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/Writing/Setup.cs
+++ b/tests/Writing/Setup.cs
@@ -18,6 +18,8 @@ namespace Writing
                 using (lasPointRecord pt = new lasPointRecord(lr))                
                 using (lasStreamWriter lw = new lasStreamWriter(lr, pt, TestData.WriteTestPath(file)))
                 {
+                    if (lr.SystemIdentifier == "OTHER") lw.SystemIdentifier = "OTHER";
+
                     for (ulong i = 0; i < lr.PointCount; i++)
                     {
                         pt.ReadFrom(lr);

--- a/tests/Writing/Setup.cs
+++ b/tests/Writing/Setup.cs
@@ -16,7 +16,7 @@ namespace Writing
             {
                 using (lasStreamReader lr = new lasStreamReader(file.FileName))
                 using (lasPointRecord pt = new lasPointRecord(lr))                
-                using (lasStreamWriter lw = new lasStreamWriter(lr, pt, Utility.WritePath(file)))
+                using (lasStreamWriter lw = new lasStreamWriter(lr, pt, TestData.WriteTestPath(file)))
                 {
                     for (ulong i = 0; i < lr.PointCount; i++)
                     {
@@ -31,14 +31,6 @@ namespace Writing
         public static void ClearWriteTests(TestContext c) 
         {
             Directory.Delete(TestData.WritePath, true);
-        }
-    }
-
-    internal class Utility
-    {
-        internal static string WritePath(BaseFileInfo test_file)
-        {
-            return Path.Combine(TestData.WritePath, Path.GetFileName(test_file.FileName));
         }
     }
 }

--- a/tests/Writing/Setup.cs
+++ b/tests/Writing/Setup.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using streamlas;
+using tests;
+
+namespace Writing
+{
+    [TestClass]
+    public class Setup
+    {
+        [AssemblyInitialize]
+        public static void WriteBaseFiles(TestContext c)
+        {
+            if (!Directory.Exists(TestData.WritePath)) Directory.CreateDirectory(TestData.WritePath);
+            foreach (var file in TestData.BaseFiles)
+            {
+                using (lasStreamReader lr = new lasStreamReader(file.FileName))
+                using (lasPointRecord pt = new lasPointRecord(lr))                
+                using (lasStreamWriter lw = new lasStreamWriter(lr, pt, Utility.WritePath(file)))
+                {
+
+                }
+            }
+        }
+
+        [AssemblyCleanup]
+        public static void ClearWriteTests(TestContext c) 
+        {
+            Directory.Delete(TestData.WritePath, true);
+        }
+    }
+
+    internal class Utility
+    {
+        internal static string WritePath(BaseFileInfo test_file)
+        {
+            return Path.Combine(TestData.WritePath, Path.GetFileName(test_file.FileName));
+        }
+    }
+}

--- a/tests/Writing/Setup.cs
+++ b/tests/Writing/Setup.cs
@@ -18,7 +18,11 @@ namespace Writing
                 using (lasPointRecord pt = new lasPointRecord(lr))                
                 using (lasStreamWriter lw = new lasStreamWriter(lr, pt, Utility.WritePath(file)))
                 {
-
+                    for (ulong i = 0; i < lr.PointCount; i++)
+                    {
+                        pt.ReadFrom(lr);
+                        lw.WritePoint(pt);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Implements basic LAS writing functionality. At present, all point formats for LAS versions 1.1 - 1.4 can be read and written. While all point formats can be read and re-written, the following point attributes are not exposed:
 - RGB(N) color values
 - Full Waveform information
 - Any custom 'extra bytes'

As point modifications have not yet been implemented, code at this stage enables mainly read only tasks of data. The basic writing functionality allows for simple tasks like writing subsets of existing files, or combining multiple files into one. 

The `lasStreamReader` and `lasStreamWriter` objects do not presently support the reading of, modifying, or writing of any variable length records (VLRs) or extended variable length records (EVLRs). See ASPRS LAS file format specifications for details.