### PR TITLE
Point modification

### DIFF
--- a/source/lasPointRecord.cs
+++ b/source/lasPointRecord.cs
@@ -25,7 +25,10 @@ namespace streamlas
         public double X { get { return point_base.X * scale[0] + offset[0]; } }
         public double Y { get { return point_base.Y * scale[1] + offset[1]; } }
         public double Z { get { return point_base.Z * scale[2] + offset[2]; } }
-        public ushort Intensity { get { return point_base.Intensity; } }
+        public ushort Intensity { 
+            get { return point_base.Intensity; } 
+            set { point_base.Intensity = value; }
+        }
 
         public byte ReturnNumber { get { return return_number(); } }
         get_byte return_number;

--- a/source/lasPointRecord.cs
+++ b/source/lasPointRecord.cs
@@ -24,9 +24,21 @@ namespace streamlas
         private PointBlockModern point_block_modern;
         void_method assign_point_block;
 
-        public double X { get { return point_base.X * scale[0] + offset[0]; } }
-        public double Y { get { return point_base.Y * scale[1] + offset[1]; } }
-        public double Z { get { return point_base.Z * scale[2] + offset[2]; } }
+        public double X 
+        { 
+            get { return point_base.X * scale[0] + offset[0]; } 
+            set { point_base.X = (int)Math.Round((value - offset[0]) / scale[0]); }
+        }
+        public double Y 
+        {
+            get { return point_base.Y * scale[1] + offset[1]; }
+            set { point_base.Y = (int)Math.Round((value - offset[1]) / scale[1]); }
+        }
+        public double Z 
+        { 
+            get { return point_base.Z * scale[2] + offset[2]; }
+            set { point_base.Z = (int)Math.Round((value - offset[2]) / scale[2]); }
+        }
 
         public ushort Intensity 
         { 

--- a/source/lasPointRecord.cs
+++ b/source/lasPointRecord.cs
@@ -25,7 +25,9 @@ namespace streamlas
         public double X { get { return point_base.X * scale[0] + offset[0]; } }
         public double Y { get { return point_base.Y * scale[1] + offset[1]; } }
         public double Z { get { return point_base.Z * scale[2] + offset[2]; } }
-        public ushort Intensity { 
+
+        public ushort Intensity 
+        { 
             get { return point_base.Intensity; } 
             set { point_base.Intensity = value; }
         }
@@ -87,10 +89,17 @@ namespace streamlas
         byte scanner_channel_legacy() { throw new InvalidOperationException("Scanner Channel field not defined for point format " + format); }
         byte scanner_channel_modern() { return (byte)((point_base.BitGroupTwo & 48) >> 4); }
 
-        public byte UserData { get { return user_data(); } }
+        public byte UserData 
+        { 
+            get { return user_data(); }
+            set { set_user_data(value); }
+        }
         get_byte user_data;
         byte user_data_legacy() {  return point_block_legacy.UserData; }    
         byte user_data_modern() { return point_block_modern.UserData; }
+        set_byte set_user_data;
+        void set_user_data_legacy(byte v) { point_block_legacy.UserData = v; }
+        void set_user_data_modren(byte v) { point_block_modern.UserData = v; }
 
         public double ScanAngle { get { return scan_angle(); } }
         get_double scan_angle;
@@ -145,6 +154,7 @@ namespace streamlas
                 time_index = 20;
 
                 set_classification = set_classification_legacy;
+                set_user_data = set_user_data_legacy;
             }
             else
             {
@@ -166,6 +176,7 @@ namespace streamlas
                 time_index = 22;
 
                 set_classification = set_classification_modern;
+                set_user_data = set_user_data_modren;
             }
         }
 

--- a/source/lasPointRecord.cs
+++ b/source/lasPointRecord.cs
@@ -19,9 +19,9 @@ namespace streamlas
         private double[] offset;
         internal byte[] raw_data;
 
-        private PointBase point_base;
-        private PointBlockLegacy point_block_legacy;
-        private PointBlockModern point_block_modern;
+        internal PointBase point_base;
+        internal PointBlockLegacy point_block_legacy;
+        internal PointBlockModern point_block_modern;
         void_method assign_point_block;
 
         public double X 

--- a/source/lasPointRecord.cs
+++ b/source/lasPointRecord.cs
@@ -8,6 +8,7 @@ namespace streamlas
     internal delegate double get_double();
     internal delegate void void_method();
 
+    internal delegate void set_bool(bool v);
     internal delegate void set_byte(byte v);
     internal delegate void set_UInt16(UInt16 v);
 
@@ -60,20 +61,38 @@ namespace streamlas
         bool synthetic_legacy() { return (point_base.BitGroupTwo & 32) == 32; }
         bool synthetic_modern() { return (point_base.BitGroupTwo & 1) == 1; }
 
-        public bool KeypointFlag { get { return keypoint(); } }
+        public bool KeypointFlag 
+        { 
+            get { return keypoint(); }
+            set { set_keypoint(value); }
+        }
         get_bool keypoint;
         bool keypoint_legacy() { return (point_base.BitGroupTwo & 64) == 64; }
         bool keypoint_modern() { return (point_base.BitGroupTwo & 2) == 2; }
+        set_bool set_keypoint;
+        void set_keypoint_legacy(bool v) { point_base.BitGroupTwo = (byte)(point_base.BitGroupTwo ^ 64); }
+        void set_keypoint_modern(bool v) { point_base.BitGroupTwo = (byte)(point_base.BitGroupTwo ^ 2); }
 
-        public bool WithheldFlag { get { return withheld(); } }
+        public bool WithheldFlag 
+        { 
+            get { return withheld(); }
+            set { set_withheld(value); }
+        }
         get_bool withheld;
         bool withheld_legacy() { return (point_base.BitGroupTwo & 128) == 128; }
         bool withheld_modern() { return (point_base.BitGroupTwo & 4) == 4; }
+        set_bool set_withheld;
+        void set_withheld_legacy(bool v) { point_base.BitGroupTwo = (byte)(point_base.BitGroupTwo ^ 128); }
+        void set_withheld_modern(bool v) { point_base.BitGroupTwo = (byte)(point_base.BitGroupTwo ^ 4); }
 
-        public bool OverlapFlag() {  return overlap(); } 
+        public bool OverlapFlag() {  return overlap(); }
+        public void OverlapFlag(bool v) { set_overlap(v); }
         get_bool overlap;
         bool overlap_legacy() { throw new InvalidOperationException("Overlap flag not defined for point format " + format); }
         bool overlap_modern() { return (point_base.BitGroupTwo & 8) == 8; }
+        set_bool set_overlap;
+        void set_overlap_legacy(bool v) { throw new InvalidOperationException("Overlap flag not defined for point format " + format); }
+        void set_overlap_modern(bool v) { point_base.BitGroupTwo = (byte)(point_base.BitGroupTwo ^ 8); }
 
         public bool ScanDirectionFlag { get { return scan_direction(); } }
         get_bool scan_direction;
@@ -164,6 +183,9 @@ namespace streamlas
                 set_classification = set_classification_legacy;
                 set_user_data = set_user_data_legacy;
                 set_source_id = set_source_id_legacy;
+                set_keypoint = set_keypoint_legacy;
+                set_withheld = set_withheld_legacy;
+                set_overlap = set_overlap_legacy;
             }
             else
             {
@@ -187,6 +209,9 @@ namespace streamlas
                 set_classification = set_classification_modern;
                 set_user_data = set_user_data_modren;
                 set_source_id = set_source_id_modern;
+                set_keypoint = set_keypoint_modern;
+                set_withheld = set_withheld_modern;
+                set_overlap = set_overlap_modern;
             }
         }
 

--- a/source/lasPointRecord.cs
+++ b/source/lasPointRecord.cs
@@ -9,6 +9,7 @@ namespace streamlas
     internal delegate void void_method();
 
     internal delegate void set_byte(byte v);
+    internal delegate void set_UInt16(UInt16 v);
 
     public class lasPointRecord : IDisposable
     {
@@ -106,10 +107,17 @@ namespace streamlas
         double scan_angle_legacy() { return point_block_legacy.ScanAngleRank; }
         double scan_angle_modern() { return point_block_modern.ScanAngle * 0.006; }
 
-        public UInt16 SourceID { get { return source_id(); } }
+        public UInt16 SourceID 
+        { 
+            get { return source_id(); }
+            set { set_source_id(value); }
+        }
         get_UInt16 source_id;
         UInt16 source_id_legacy() { return point_block_legacy.PointSourceID; }
         UInt16 source_id_modern() { return point_block_modern.PointSourceID; }
+        set_UInt16 set_source_id;
+        void set_source_id_legacy(UInt16 v) { point_block_legacy.PointSourceID = v; }
+        void set_source_id_modern(UInt16 v) { point_block_modern.PointSourceID = v; }
         
         public double Timestamp() { return get_time(); }
         private int time_index;
@@ -155,6 +163,7 @@ namespace streamlas
 
                 set_classification = set_classification_legacy;
                 set_user_data = set_user_data_legacy;
+                set_source_id = set_source_id_legacy;
             }
             else
             {
@@ -177,6 +186,7 @@ namespace streamlas
 
                 set_classification = set_classification_modern;
                 set_user_data = set_user_data_modren;
+                set_source_id = set_source_id_modern;
             }
         }
 

--- a/source/lasPointRecord.cs
+++ b/source/lasPointRecord.cs
@@ -8,6 +8,8 @@ namespace streamlas
     internal delegate double get_double();
     internal delegate void void_method();
 
+    internal delegate void set_byte(byte v);
+
     public class lasPointRecord : IDisposable
     {
         internal byte format;
@@ -35,10 +37,17 @@ namespace streamlas
         byte number_returns_legacy() { return (byte)((point_base.BitGroupOne & 56) >> 3); }
         byte number_returns_modern() { return (byte)((point_base.BitGroupOne & 240) >> 4); }
 
-        public byte Classification { get { return classification(); } }
+        public byte Classification 
+        { 
+            get { return classification(); } 
+            set { set_classification(value); }        
+        }
         get_byte classification;
         byte classification_legacy() { return (byte)(point_base.BitGroupTwo & 31); }
         byte classification_modern() { return point_block_modern.Classification; }
+        set_byte set_classification;
+        void set_classification_legacy(byte v) { point_base.BitGroupTwo = (byte)((point_base.BitGroupTwo & 224) ^ (v & 31)); }
+        void set_classification_modern(byte v) { point_block_modern.Classification = v; }
 
         public bool SyntheticFlag { get { return synthetic(); } }
         get_bool synthetic;
@@ -131,6 +140,8 @@ namespace streamlas
                     get_time = timestamp;
                 }
                 time_index = 20;
+
+                set_classification = set_classification_legacy;
             }
             else
             {
@@ -150,6 +161,8 @@ namespace streamlas
                 assign_point_block = assign_point_block_modern;                
                 get_time = timestamp;
                 time_index = 22;
+
+                set_classification = set_classification_modern;
             }
         }
 

--- a/source/lasPointStructs.cs
+++ b/source/lasPointStructs.cs
@@ -7,9 +7,6 @@ namespace streamlas
     internal unsafe struct PointBase
     {
         [FieldOffset(0)]
-        internal fixed byte data[16];
-
-        [FieldOffset(0)]
         internal int X;
 
         [FieldOffset(4)]
@@ -32,9 +29,6 @@ namespace streamlas
     internal unsafe struct PointBlockLegacy
     {
         [FieldOffset(0)]
-        internal fixed byte data[4];
-
-        [FieldOffset(0)]
         internal sbyte ScanAngleRank;
 
         [FieldOffset(1)]
@@ -47,9 +41,6 @@ namespace streamlas
     [StructLayout(LayoutKind.Explicit)]
     internal unsafe struct PointBlockModern
     {
-        [FieldOffset(0)]
-        internal fixed byte data[14];
-
         [FieldOffset(0)]
         internal byte Classification;
 

--- a/source/lasPointStructs.cs
+++ b/source/lasPointStructs.cs
@@ -4,8 +4,11 @@ using System.Runtime.InteropServices;
 namespace streamlas
 {
     [StructLayout(LayoutKind.Explicit)]
-    internal struct PointBase
+    internal unsafe struct PointBase
     {
+        [FieldOffset(0)]
+        internal fixed byte data[16];
+
         [FieldOffset(0)]
         internal int X;
 
@@ -26,8 +29,11 @@ namespace streamlas
     }
 
     [StructLayout(LayoutKind.Explicit)]
-    internal struct PointBlockLegacy
+    internal unsafe struct PointBlockLegacy
     {
+        [FieldOffset(0)]
+        internal fixed byte data[4];
+
         [FieldOffset(0)]
         internal sbyte ScanAngleRank;
 
@@ -39,8 +45,11 @@ namespace streamlas
     }
 
     [StructLayout(LayoutKind.Explicit)]
-    internal struct PointBlockModern
+    internal unsafe struct PointBlockModern
     {
+        [FieldOffset(0)]
+        internal fixed byte data[14];
+
         [FieldOffset(0)]
         internal byte Classification;
 

--- a/source/lasStreamWriter.cs
+++ b/source/lasStreamWriter.cs
@@ -6,13 +6,15 @@ using System.Text;
 
 namespace streamlas
 {
+    internal delegate void lasPointMethod(lasPointRecord p);
+
     public class lasStreamWriter : IDisposable
-    {
-        
+    {        
         internal BinaryWriter writer;
         internal string file_name;
         
         private byte point_format;
+        private int excess_point_bytes;
         private byte version_minor;
         private HashSet<UInt16> src_ids = new HashSet<ushort>();
 
@@ -27,6 +29,18 @@ namespace streamlas
         {
             point_format = point.format;
             version_minor = reader.VersionMinor;
+            if (point_format < 6)
+            {
+                write_point_block = write_point_block_legacy;
+                excess_point_bytes = point.raw_data.Length - 20;
+                if (excess_point_bytes > 0) write_point_block = write_point_block_legacy_excess;
+            }
+            else
+            {
+                write_point_block = write_point_block_modern;
+                excess_point_bytes = point.raw_data.Length - 30;
+                if (excess_point_bytes > 0) write_point_block = write_point_block_modern_excess;
+            }
 
             file_name = path;
             writer = new BinaryWriter(File.Create(path));
@@ -74,18 +88,6 @@ namespace streamlas
 
         public unsafe void WritePoint(lasPointRecord point)
         {
-            if (point.format == 0)
-            {
-                fixed (byte* b = point.point_base.data) for (int i = 0; i < 16; i++) writer.Write(b[i]);
-                fixed (byte* b = point.point_block_legacy.data) for (int i = 0; i < 4; i++) writer.Write(b[i]);
-            }
-            else if (point.format == 6)
-            {
-                fixed (byte* b = point.point_base.data) for (int i = 0; i < 16; i++) writer.Write(b[i]);
-                fixed (byte* b = point.point_block_modern.data) for (int i = 0; i < 14; i++) writer.Write(b[i]);
-            }
-            else writer.Write(point.raw_data);
-
             count++;
             return_counts[point.ReturnNumber - 1]++;
             src_ids.Add(point.SourceID);
@@ -97,6 +99,50 @@ namespace streamlas
             max_coords[0] = (max_coords[0] > point.X) ? max_coords[0] : point.X;
             max_coords[1] = (max_coords[1] > point.Y) ? max_coords[1] : point.Y;
             max_coords[2] = (max_coords[2] > point.Z) ? max_coords[2] : point.Z;
+
+            writer.Write(point.point_base.X);
+            writer.Write(point.point_base.Y);
+            writer.Write(point.point_base.Z);
+            writer.Write(point.point_base.Intensity);
+            writer.Write(point.point_base.BitGroupOne);
+            writer.Write(point.point_base.BitGroupTwo);
+            write_point_block(point);
+        }
+
+        lasPointMethod write_point_block;
+
+        void write_point_block_legacy(lasPointRecord p)
+        {
+            writer.Write(p.point_block_legacy.ScanAngleRank);
+            writer.Write(p.point_block_legacy.UserData);
+            writer.Write(p.point_block_legacy.PointSourceID);
+        }
+
+        void write_point_block_legacy_excess(lasPointRecord p)
+        {
+            writer.Write(p.point_block_legacy.ScanAngleRank);
+            writer.Write(p.point_block_legacy.UserData);
+            writer.Write(p.point_block_legacy.PointSourceID);
+            for (int i = 0; i < excess_point_bytes; i++) writer.Write(p.raw_data[20 + i]);
+        }
+
+        void write_point_block_modern(lasPointRecord p)
+        {
+            writer.Write(p.point_block_modern.Classification);
+            writer.Write(p.point_block_modern.UserData);
+            writer.Write(p.point_block_modern.ScanAngle);
+            writer.Write(p.point_block_modern.PointSourceID);
+            writer.Write(p.point_block_modern.Timestamp);
+        }
+
+        void write_point_block_modern_excess(lasPointRecord p)
+        {
+            writer.Write(p.point_block_modern.Classification);
+            writer.Write(p.point_block_modern.UserData);
+            writer.Write(p.point_block_modern.ScanAngle);
+            writer.Write(p.point_block_modern.PointSourceID);
+            writer.Write(p.point_block_modern.Timestamp);
+            for (int i = 0; i < excess_point_bytes; i++) writer.Write(p.raw_data[30 + i]);
         }
 
         public void Dispose()

--- a/tests/Modifying/Export.cs
+++ b/tests/Modifying/Export.cs
@@ -1,0 +1,86 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using streamlas;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using tests;
+
+namespace Modifying
+{
+    [TestClass]
+    public class Export
+    {
+        [TestMethod, TestCategory("Integration")]
+        public void ModifiedPoints()
+        {
+            foreach (var info in TestData.BaseFiles)
+            {
+                string out_file = info.FileName.Replace(".las", "_TEMP.las");
+                var ref_pts = TestData.BaseFilePoints[info.PointFormat];
+                List<PointInfo> modified_pts = new List<PointInfo>();                
+
+                using (lasStreamReader lr = new lasStreamReader(info.FileName))
+                using (lasPointRecord pt = new lasPointRecord(lr))
+                using (lasStreamWriter lw = new lasStreamWriter(lr, pt, out_file))
+                {
+                    for (int i = 0; i < ref_pts.Count; i++)
+                    {
+                        pt.ReadFrom(lr);
+                        modified_pts.Add(ref_pts[i].Copy());
+
+                        pt.X += 150.0;
+                        modified_pts[i].X += 150.0;
+                        pt.Y -= 250.0;
+                        modified_pts[i].Y -= 250.0;
+                        pt.Z += 300.0;
+                        modified_pts[i].Z += 300.0;
+                        pt.Intensity = (UInt16)(((lr.PointFormat + 1) / 10) * 65000);
+                        modified_pts[i].Intensity = (UInt16)(((lr.PointFormat + 1) / 10) * 65000);
+                        
+                        pt.KeypointFlag = !ref_pts[i].KeypointFlag;
+                        modified_pts[i].KeypointFlag = !ref_pts[i].KeypointFlag;
+                        pt.WithheldFlag = !ref_pts[i].WithheldFlag;
+                        modified_pts[i].WithheldFlag = !ref_pts[i].WithheldFlag;
+                        
+                        if (lr.PointFormat < 6)
+                        {
+                            pt.Classification = (byte)((ref_pts[i].Classification + 1) % 32);
+                            modified_pts[i].Classification = (byte)((ref_pts[i].Classification + 1) % 32);
+                        }
+                        else
+                        {
+                            pt.Classification = (byte)((ref_pts[i].Classification + 1) % 256);
+                            modified_pts[i].Classification = (byte)((ref_pts[i].Classification + 1) % 256);
+                            pt.OverlapFlag(!ref_pts[i].OverlapFlag);
+                            modified_pts[i].OverlapFlag = !ref_pts[i].OverlapFlag;
+                        }
+                        
+                        lw.WritePoint(pt);
+                    }
+                }
+
+                using (lasStreamReader lr = new lasStreamReader(out_file))
+                using (lasPointRecord pt = new lasPointRecord(lr))
+                {
+                    for (int i = 0; i < modified_pts.Count; i++)
+                    {
+                        pt.ReadFrom(lr);
+                        Assert.AreEqual(modified_pts[i].X, pt.X, 1e-6);
+                        Assert.AreEqual(modified_pts[i].Y, pt.Y, 1e-6);
+                        Assert.AreEqual(modified_pts[i].Z, pt.Z, 1e-6);
+                        Assert.AreEqual(modified_pts[i].Intensity, pt.Intensity);
+                        Assert.AreEqual(modified_pts[i].Classification, pt.Classification);
+                        Assert.AreEqual(modified_pts[i].KeypointFlag, pt.KeypointFlag);
+                        Assert.AreEqual(modified_pts[i].WithheldFlag, pt.WithheldFlag);
+                        if (lr.PointFormat > 5)
+                        {
+                            Assert.AreEqual(modified_pts[i].OverlapFlag, pt.OverlapFlag());
+                        }
+                    }
+                }
+
+                File.Delete(out_file);
+            }
+        }
+    }
+}

--- a/tests/Modifying/Points.cs
+++ b/tests/Modifying/Points.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using streamlas;
+using System.IO;
+using tests;
+
+namespace Modifying
+{
+    [TestClass]
+    public class Points
+    {
+        private lasPointRecord[] point_per_format = new lasPointRecord[11];
+        private PointInfo[] ref_points = new PointInfo[11];
+
+        [TestInitialize]
+        public void ReadPoints()
+        {
+            for (int pfmt = 0; pfmt < 11; pfmt++)
+            {
+                string las_file = Path.Combine(TestData.BasePath, string.Format("LAS_14_PF_{0:00}.las", pfmt));
+                using (lasStreamReader lr = new lasStreamReader(las_file))
+                {
+                    point_per_format[pfmt] = new lasPointRecord(lr);
+                    point_per_format[pfmt].ReadFrom(lr);
+                }
+
+                ref_points[pfmt] = TestData.BaseFilePoints[(byte)pfmt][0];
+            }
+        }
+
+        [TestMethod]
+        public void Classification()
+        {
+            for (int i = 0; i < 11; i++)
+            {
+                point_per_format[i].Classification = (byte)((point_per_format[i].Classification + 1) % 255);
+                byte ref_class = (byte)((ref_points[i].Classification + 1) % 255);
+                Assert.AreEqual(ref_class, point_per_format[i].Classification);
+            }
+        }
+    }
+}

--- a/tests/Modifying/Points.cs
+++ b/tests/Modifying/Points.cs
@@ -51,5 +51,16 @@ namespace Modifying
                 Assert.AreEqual(int_val, point_per_format[i].Intensity);
             }
         }
+
+        [TestMethod]
+        public void UserData()
+        {
+            for (int i = 0; i < 11; i++)
+            {
+                byte ud = (byte)((i + 1) * 5);
+                point_per_format[i].UserData = ud;
+                Assert.AreEqual(ud, point_per_format[i].UserData);
+            }
+        }
     }
 }

--- a/tests/Modifying/Points.cs
+++ b/tests/Modifying/Points.cs
@@ -53,6 +53,12 @@ namespace Modifying
                 Assert.AreEqual(kp_flag, point_per_format[i].KeypointFlag);
                 Assert.AreEqual(wh_flag, point_per_format[i].WithheldFlag);
 
+                if (i < 6)
+                {
+                    var ex = Assert.Throws<InvalidOperationException>(() => point_per_format[i].OverlapFlag(true));
+                    Assert.IsTrue(ex.Message.Contains("Overlap flag not defined for point format"));
+                }
+
                 if (i > 5)
                 {
                     bool over_flag = !point_per_format[i].OverlapFlag();

--- a/tests/Modifying/Points.cs
+++ b/tests/Modifying/Points.cs
@@ -40,6 +40,29 @@ namespace Modifying
         }
 
         [TestMethod]
+        public void BitFlags()
+        {
+            for (int i = 0; i < point_per_format.Length; i++)
+            {
+                bool kp_flag = !point_per_format[i].KeypointFlag;
+                bool wh_flag = !point_per_format[i].WithheldFlag;
+
+                point_per_format[i].KeypointFlag = kp_flag;
+                point_per_format[i].WithheldFlag = wh_flag;
+
+                Assert.AreEqual(kp_flag, point_per_format[i].KeypointFlag);
+                Assert.AreEqual(wh_flag, point_per_format[i].WithheldFlag);
+
+                if (i > 5)
+                {
+                    bool over_flag = !point_per_format[i].OverlapFlag();
+                    point_per_format[i].OverlapFlag(over_flag);
+                    Assert.AreEqual(over_flag, point_per_format[i].OverlapFlag());
+                }
+            }
+        }
+
+        [TestMethod]
         public void Intensity()
         {
             for (int i = 0; i < point_per_format.Length; i++)

--- a/tests/Modifying/Points.cs
+++ b/tests/Modifying/Points.cs
@@ -62,5 +62,16 @@ namespace Modifying
                 Assert.AreEqual(ud, point_per_format[i].UserData);
             }
         }
+
+        [TestMethod]
+        public void PointSourceID()
+        {
+            for (int i = 0; i < 11; i++)
+            {
+                UInt16 src_id = (UInt16)((i + 1) * 100);
+                point_per_format[i].SourceID = src_id;
+                Assert.AreEqual(src_id, point_per_format[i].SourceID);
+            }
+        }
     }
 }

--- a/tests/Modifying/Points.cs
+++ b/tests/Modifying/Points.cs
@@ -10,7 +10,6 @@ namespace Modifying
     public class Points
     {
         private lasPointRecord[] point_per_format = new lasPointRecord[11];
-        private PointInfo[] ref_points = new PointInfo[11];
 
         [TestInitialize]
         public void ReadPoints()
@@ -23,28 +22,27 @@ namespace Modifying
                     point_per_format[pfmt] = new lasPointRecord(lr);
                     point_per_format[pfmt].ReadFrom(lr);
                 }
-
-                ref_points[pfmt] = TestData.BaseFilePoints[(byte)pfmt][0];
             }
         }
 
         [TestMethod]
         public void Classification()
         {
-            for (int i = 0; i < 11; i++)
+            for (int i = 0; i < point_per_format.Length; i++)
             {
                 int num_classes = 32;
                 if (i > 5) num_classes = 256;
-                point_per_format[i].Classification = (byte)((point_per_format[i].Classification + 1) % num_classes);
-                byte ref_class = (byte)((ref_points[i].Classification + 1) % num_classes);
-                Assert.AreEqual(ref_class, point_per_format[i].Classification);
+
+                byte class_val = (byte)(num_classes * (i + 1) / 10.0);
+                point_per_format[i].Classification = class_val;
+                Assert.AreEqual(class_val, point_per_format[i].Classification);
             }
         }
 
         [TestMethod]
         public void Intensity()
         {
-            for (int i = 0; i < 11; i++)
+            for (int i = 0; i < point_per_format.Length; i++)
             {
                 UInt16 int_val = (UInt16)(UInt16.MaxValue * (i / 10.0));
                 point_per_format[i].Intensity = int_val;
@@ -55,7 +53,7 @@ namespace Modifying
         [TestMethod]
         public void UserData()
         {
-            for (int i = 0; i < 11; i++)
+            for (int i = 0; i < point_per_format.Length; i++)
             {
                 byte ud = (byte)((i + 1) * 5);
                 point_per_format[i].UserData = ud;
@@ -66,7 +64,7 @@ namespace Modifying
         [TestMethod]
         public void PointSourceID()
         {
-            for (int i = 0; i < 11; i++)
+            for (int i = 0; i < point_per_format.Length; i++)
             {
                 UInt16 src_id = (UInt16)((i + 1) * 100);
                 point_per_format[i].SourceID = src_id;

--- a/tests/Modifying/Points.cs
+++ b/tests/Modifying/Points.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using streamlas;
+using System;
 using System.IO;
 using tests;
 
@@ -37,6 +38,17 @@ namespace Modifying
                 point_per_format[i].Classification = (byte)((point_per_format[i].Classification + 1) % num_classes);
                 byte ref_class = (byte)((ref_points[i].Classification + 1) % num_classes);
                 Assert.AreEqual(ref_class, point_per_format[i].Classification);
+            }
+        }
+
+        [TestMethod]
+        public void Intensity()
+        {
+            for (int i = 0; i < 11; i++)
+            {
+                UInt16 int_val = (UInt16)(UInt16.MaxValue * (i / 10.0));
+                point_per_format[i].Intensity = int_val;
+                Assert.AreEqual(int_val, point_per_format[i].Intensity);
             }
         }
     }

--- a/tests/Modifying/Points.cs
+++ b/tests/Modifying/Points.cs
@@ -26,6 +26,25 @@ namespace Modifying
         }
 
         [TestMethod]
+        public void Coordinates()
+        {
+            for (int i = 0; i < point_per_format.Length; i++)
+            {
+                double x = point_per_format[i].X + 1500.0;
+                double y = point_per_format[i].Y + 2750.0;
+                double z = point_per_format[i].Z + 310.0;
+
+                point_per_format[i].X = x;
+                point_per_format[i].Y = y;
+                point_per_format[i].Z = z;
+
+                Assert.AreEqual(x, point_per_format[i].X, 1e-6);
+                Assert.AreEqual(y, point_per_format[i].Y, 1e-6);
+                Assert.AreEqual(z, point_per_format[i].Z, 1e-6);
+            }
+        }
+
+        [TestMethod]
         public void Classification()
         {
             for (int i = 0; i < point_per_format.Length; i++)

--- a/tests/Modifying/Points.cs
+++ b/tests/Modifying/Points.cs
@@ -32,8 +32,10 @@ namespace Modifying
         {
             for (int i = 0; i < 11; i++)
             {
-                point_per_format[i].Classification = (byte)((point_per_format[i].Classification + 1) % 255);
-                byte ref_class = (byte)((ref_points[i].Classification + 1) % 255);
+                int num_classes = 32;
+                if (i > 5) num_classes = 256;
+                point_per_format[i].Classification = (byte)((point_per_format[i].Classification + 1) % num_classes);
+                byte ref_class = (byte)((ref_points[i].Classification + 1) % num_classes);
                 Assert.AreEqual(ref_class, point_per_format[i].Classification);
             }
         }

--- a/tests/Reading/HeaderExceptions.cs
+++ b/tests/Reading/HeaderExceptions.cs
@@ -17,7 +17,7 @@ namespace Reading
                 {
                     IOException ex = Assert.ThrowsException<IOException>(() => new lasStreamReader(file.FileName));
                     Assert.IsTrue(ex.Message.Contains("not a properly formatted LAS file"));
-                    Assert.AreEqual(ex.Data["FileName"], Path.GetFileName(file.FileName));
+                    Assert.AreEqual(Path.GetFileName(file.FileName), ex.Data["FileName"]);
                 }
             }
         }
@@ -32,7 +32,7 @@ namespace Reading
                 {
                     IOException ex = Assert.ThrowsException<IOException>(() => new lasStreamReader(file.FileName));
                     Assert.IsTrue(ex.Message.Contains("is unsupported or not yet defined."));
-                    Assert.AreEqual(ex.Data["FileName"], Path.GetFileName(file.FileName));
+                    Assert.AreEqual(Path.GetFileName(file.FileName), ex.Data["FileName"]);
                 }
             }
         }
@@ -46,7 +46,7 @@ namespace Reading
                 {
                     IOException ex = Assert.ThrowsException<IOException>(() => new lasStreamReader(file.FileName));
                     Assert.IsTrue(ex.Message.Contains("not supported in LAS v"));
-                    Assert.AreEqual(ex.Data["FileName"], Path.GetFileName(file.FileName));
+                    Assert.AreEqual(Path.GetFileName(file.FileName), ex.Data["FileName"]);
                 }
             }
         }
@@ -60,7 +60,7 @@ namespace Reading
                 {
                     IOException ex = Assert.ThrowsException<IOException>(() => new lasStreamReader(file.FileName));
                     Assert.IsTrue(ex.Message.Contains("Reported point record size smaller than minimum required for Point Format"));
-                    Assert.AreEqual(ex.Data["FileName"], Path.GetFileName(file.FileName));
+                    Assert.AreEqual(Path.GetFileName(file.FileName), ex.Data["FileName"]);
                 }
             }
         }
@@ -74,7 +74,7 @@ namespace Reading
                 {
                     IOException ex = Assert.Throws<IOException>(() => new lasStreamReader(file.FileName));
                     Assert.IsTrue(ex.Message.Contains("Reported header size incorrect for LAS v"));
-                    Assert.AreEqual(ex.Data["FileName"], Path.GetFileName(file.FileName));
+                    Assert.AreEqual(Path.GetFileName(file.FileName), ex.Data["FileName"]);
                 }
             }
         }
@@ -88,7 +88,7 @@ namespace Reading
                 {
                     IOException ex = Assert.Throws<IOException>(() => new lasStreamReader(file.FileName));
                     Assert.IsTrue(ex.Message.Contains("Inconsistency between Point Count and Legacy Point Count Fields."));
-                    Assert.AreEqual(ex.Data["FileName"], Path.GetFileName(file.FileName));
+                    Assert.AreEqual(Path.GetFileName(file.FileName), ex.Data["FileName"]);
                 }
             }
         }
@@ -102,7 +102,7 @@ namespace Reading
                 {
                     IOException ex = Assert.Throws<IOException>(() => new lasStreamReader(file.FileName));
                     Assert.IsTrue(ex.Message.Contains("Point Format > 5 but legacy point count fields have non-zero values."));
-                    Assert.AreEqual(ex.Data["FileName"], Path.GetFileName(file.FileName));
+                    Assert.AreEqual(Path.GetFileName(file.FileName), ex.Data["FileName"]);
                 }
             }
         }
@@ -116,7 +116,7 @@ namespace Reading
                 {
                     IOException ex = Assert.Throws<IOException>(() => new lasStreamReader(file.FileName));
                     Assert.IsTrue(ex.Message.Contains("Reported offset to points shorter than header size for LAS v"));
-                    Assert.AreEqual(ex.Data["FileName"], Path.GetFileName(file.FileName));
+                    Assert.AreEqual(Path.GetFileName(file.FileName), ex.Data["FileName"]);
                 }
             }
         }
@@ -130,7 +130,7 @@ namespace Reading
                 {
                     IOException ex = Assert.Throws<IOException>(() => new lasStreamReader(file.FileName));
                     Assert.IsTrue(ex.Message.Contains("length is inconsistent with point size and count."));
-                    Assert.AreEqual(ex.Data["FileName"], Path.GetFileName(file.FileName));
+                    Assert.AreEqual(Path.GetFileName(file.FileName), ex.Data["FileName"]);
                 }
             }
         }

--- a/tests/TestData.cs
+++ b/tests/TestData.cs
@@ -54,6 +54,32 @@ namespace tests
         public byte UserData { get; set; }
         public Int16 ScanAngle { get; set; }
         public double Timestamp { get; set; }
+
+        public PointInfo Copy()
+        {
+            var copy = new PointInfo();
+
+            copy.X = X;
+            copy.Y = Y;
+            copy.Z = Z;
+            copy.Intensity = Intensity;
+            copy.Classification = Classification;
+            copy.Return = Return;
+            copy.NumberReturns = NumberReturns;
+            copy.SyntheticFlag = SyntheticFlag;
+            copy.KeypointFlag = KeypointFlag;
+            copy.WithheldFlag = WithheldFlag;
+            copy.OverlapFlag = OverlapFlag;
+            copy.ScanDirectionFlag = ScanDirectionFlag;
+            copy.EdgeOfFlightLineFlag = EdgeOfFlightLineFlag;
+            copy.ScannerChannel = ScannerChannel;
+            copy.SourceID = SourceID;
+            copy.UserData = UserData;
+            copy.ScanAngle = ScanAngle;
+            copy.Timestamp = Timestamp;
+
+            return copy;
+        }
     }
 
     internal static class TestData

--- a/tests/TestData.cs
+++ b/tests/TestData.cs
@@ -61,6 +61,7 @@ namespace tests
         internal static readonly List<ErrorFileInfo> ErrorFiles;
         internal static readonly List<BaseFileInfo> BaseFiles;
         internal static readonly Dictionary<byte, List<PointInfo>> BaseFilePoints;
+        internal static readonly string BasePath;
         internal static readonly string WritePath;
 
         internal static List<ErrorFileInfo> GetErrorFileInfo(string data_dir, string json_file)
@@ -96,13 +97,13 @@ namespace tests
             string data_dir = "../../../Data/ErrorFiles/";
             ErrorFiles = GetErrorFileInfo(data_dir, data_dir + "ErrorFiles.json");
 
-            data_dir = "../../../Data/BaseFiles/";
-            BaseFiles = GetBaseFileInfo(data_dir, data_dir + "BaseFiles.json");
+            BasePath = "../../../Data/BaseFiles/";
+            BaseFiles = GetBaseFileInfo(BasePath, BasePath + "BaseFiles.json");
 
             BaseFilePoints = new Dictionary<byte, List<PointInfo>>();
             for (byte pfmt = 0; pfmt < 11; pfmt++)
             {
-                string point_file = data_dir + string.Format("PointFormat_{0:00}.json", pfmt);
+                string point_file = BasePath + string.Format("PointFormat_{0:00}.json", pfmt);
                 BaseFilePoints.Add(pfmt, GetPointInfo(point_file));
             }
 


### PR DESCRIPTION
Implements basic point record modification functionality. The following attributes can now be modified:
 - Coordinates
 - Intensity
 - Classification
 - Source ID
 - User Data
 - Keypoint Flag
 - Withheld Flag
 - Overlap Flag (for point formats > 5)  

The remaining attributes are considered *read only* at present, as they relate mainly to sensor / acquisition details. While the **intensity** is sensor derived, there are times when the value warrants direct modification for creation of specific visuals or application of radiometric processing techniques.  

It is worth noting that while coordinate values may be modified, this should be done cautiously. The conversion from the accessible floating point XYZ values back to the 32-bit integers stored in LAS data will not be valid for all real numbers. Users are advised to consult the LAS format specification for details.